### PR TITLE
JBIDE-14019 - Fix missing icon in Servers View

### DIFF
--- a/plugins/org.jboss.tools.livereload/build.properties
+++ b/plugins/org.jboss.tools.livereload/build.properties
@@ -7,5 +7,7 @@ bin.includes = META-INF/,\
                lib/jackson-core-2.1.2.jar,\
                lib/jackson-databind-2.1.2.jar,\
                lib/jericho-html-3.3.jar,\
-               script/
-src.includes = script/
+               script/,\
+               icons/
+src.includes = script/,\
+               icons/


### PR DESCRIPTION
Adding missing /icons directory in build.properties
