### PR TITLE
JBIDE-14665 - "Open In>Web Browser via LiveReload Proxy" should be enabled for .xhtml files

### DIFF
--- a/plugins/org.jboss.tools.livereload.ui/plugin.xml
+++ b/plugins/org.jboss.tools.livereload.ui/plugin.xml
@@ -102,7 +102,7 @@
          id="org.eclipse.ui.browser.editor"
          name="%viewWebBrowserTitle"/-->
       <editor
-         extensions="htm,html,shtml"
+         extensions="htm,html,xhtml,shtml"
          icon="$nl$/icons/livereload_editor_launcher.png"
          id="org.jboss.tools.livereload.openFileInBrowserWithLiveReload"
          launcher="org.jboss.tools.livereload.ui.internal.command.OpenInWebBrowserWithLiveReloadLauncher"


### PR DESCRIPTION
Added the file extension in the plugin.xml
