### PR TITLE
JBIDE-14665 - Open In>Web Browser via LiveReload Proxy" should be enabled for .xhtml files

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptInjectionFilter.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptInjectionFilter.java
@@ -14,7 +14,6 @@ package org.jboss.tools.livereload.core.internal.server.jetty;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.UnknownHostException;
-import java.util.StringTokenizer;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -32,6 +31,7 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.eclipse.jetty.continuation.Continuation;
 import org.eclipse.jetty.continuation.ContinuationListener;
 import org.eclipse.jetty.continuation.ContinuationSupport;
+import org.jboss.tools.livereload.core.internal.util.HttpUtils;
 import org.jboss.tools.livereload.core.internal.util.Logger;
 import org.jboss.tools.livereload.core.internal.util.ScriptInjectionUtils;
 
@@ -64,7 +64,7 @@ public class LiveReloadScriptInjectionFilter implements Filter {
 		final HttpServletRequest httpRequest = (HttpServletRequest) request;
 		final String acceptedContentTypes = httpRequest.getHeader("Accept");
 		Logger.trace("Processing request {} {}", httpRequest.getMethod(), httpRequest.getRequestURI());
-		if (!"/livereload".equals(httpRequest.getRequestURI()) && isHtmlContentType(acceptedContentTypes)) {
+		if (!"/livereload".equals(httpRequest.getRequestURI()) && HttpUtils.isHtmlContentType(acceptedContentTypes)) {
 			Continuation continuation = ContinuationSupport.getContinuation(request);
 			final ModifiableHttpServletResponse responseWrapper = new ModifiableHttpServletResponse(
 					(HttpServletResponse) response);
@@ -117,7 +117,7 @@ public class LiveReloadScriptInjectionFilter implements Filter {
 		// (HttpServletResponse#getContentType() returns null !)
 		final String returnedContentType = responseWrapper.getHeader("Content-Type");
 		Logger.trace(" response type: {}", returnedContentType);
-		if (isHtmlContentType(returnedContentType)) {
+		if (HttpUtils.isHtmlContentType(returnedContentType)) {
 			Logger.debug("Injecting livereload.js <script> in response for {} ({})", httpRequest.getRequestURI(),
 					returnedContentType);
 			final InputStream responseStream = responseWrapper.getResponseAsStream();
@@ -135,35 +135,6 @@ public class LiveReloadScriptInjectionFilter implements Filter {
 	}
 
 	
-	/**
-	 * <p>
-	 * Iterates over the given acceptedContentTypes, looking for one of those
-	 * values:
-	 * <ul>
-	 * <li>text/html</li>
-	 * <li>application/xhtml+xml</li>
-	 * <li>application/xml</li>
-	 * </ul>
-	 * </p>
-	 * 
-	 * @param acceptedContentTypes
-	 * @return true if one of the values above was found, false otherwise
-	 */
-	private static boolean isHtmlContentType(final String acceptedContentTypes) {
-		if (acceptedContentTypes == null) {
-			return false;
-		}
-		final StringTokenizer tokenizer = new StringTokenizer(acceptedContentTypes, ",");
-		while (tokenizer.hasMoreElements()) {
-			final String acceptedContentType = tokenizer.nextToken();
-			if ("text/html".equals(acceptedContentType) || "application/xhtml+xml".equals(acceptedContentType)
-					|| "application/xml".equals(acceptedContentType)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
 	}

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/HttpUtils.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/HttpUtils.java
@@ -1,0 +1,63 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.livereload.core.internal.util;
+
+import java.util.StringTokenizer;
+
+/**
+ * Utility for HTTP Requests
+ * @author xcoulon
+ *
+ */
+public class HttpUtils {
+
+	/**
+	 * Private constructor of this utiliy class
+	 */
+	private HttpUtils() {
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * <p>
+	 * Iterates over the given acceptedContentTypes, looking for one of those
+	 * values:
+	 * <ul>
+	 * <li>text/html</li>
+	 * <li>application/xhtml+xml</li>
+	 * <li>application/xml</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @param acceptedContentTypes
+	 * @return true if one of the values above was found, false otherwise
+	 */
+	public static boolean isHtmlContentType(final String acceptedContentTypes) {
+		if (acceptedContentTypes == null) {
+			return false;
+		}
+		// first, let's remove everything after the coma character
+		int location = acceptedContentTypes.indexOf(";");
+		final String contentTypes = (location != -1) ? acceptedContentTypes.substring(0, location):acceptedContentTypes; 
+		// now, let's analyze each type
+		final StringTokenizer tokenizer = new StringTokenizer(contentTypes, ",");
+		while (tokenizer.hasMoreElements()) {
+			final String acceptedContentType = tokenizer.nextToken();
+			if ("text/html".equals(acceptedContentType) || "application/xhtml+xml".equals(acceptedContentType)
+					|| "application/xml".equals(acceptedContentType)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
@@ -276,7 +276,7 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 	}
 
 	@Test
-	public void shouldInjectLiveReloadScriptInHtmlPage() throws Exception {
+	public void shouldInjectLiveReloadScriptInHtmlPageWithSimpleAcceptedTypes() throws Exception {
 		// pre-condition
 		createAndLaunchLiveReloadServer(true, true);
 		final String scriptContent = new StringBuilder(
@@ -286,6 +286,44 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 		HttpClient client = new HttpClient();
 		HttpMethod method = new GetMethod(indexDocumentlocation);
 		method.addRequestHeader("Accept", "text/html");
+		int status = client.executeMethod(method);
+		// verification
+		assertThat(status).isEqualTo(HttpStatus.SC_OK);
+		// Read the response body.
+		String responseBody = new String(method.getResponseBody());
+		assertThat(responseBody).contains(scriptContent);
+	}
+
+	@Test
+	public void shouldInjectLiveReloadScriptInHtmlPageWithSimpleAcceptedTypeAndcharset() throws Exception {
+		// pre-condition
+		createAndLaunchLiveReloadServer(true, true);
+		final String scriptContent = new StringBuilder(
+				"<script>document.write('<script src=\"http://' + location.host.split(':')[0]+ ':")
+		.append(liveReloadServerPort).append("/livereload.js\"></'+ 'script>')</script>").toString();
+		// operation
+		HttpClient client = new HttpClient();
+		HttpMethod method = new GetMethod(indexDocumentlocation);
+		method.addRequestHeader("Accept", "text/html;charset=UTF-8");
+		int status = client.executeMethod(method);
+		// verification
+		assertThat(status).isEqualTo(HttpStatus.SC_OK);
+		// Read the response body.
+		String responseBody = new String(method.getResponseBody());
+		assertThat(responseBody).contains(scriptContent);
+	}
+
+	@Test
+	public void shouldInjectLiveReloadScriptInHtmlPageWithMultipleAcceptedTypeAndQualityFactors() throws Exception {
+		// pre-condition
+		createAndLaunchLiveReloadServer(true, true);
+		final String scriptContent = new StringBuilder(
+				"<script>document.write('<script src=\"http://' + location.host.split(':')[0]+ ':")
+		.append(liveReloadServerPort).append("/livereload.js\"></'+ 'script>')</script>").toString();
+		// operation
+		HttpClient client = new HttpClient();
+		HttpMethod method = new GetMethod(indexDocumentlocation);
+		method.addRequestHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
 		int status = client.executeMethod(method);
 		// verification
 		assertThat(status).isEqualTo(HttpStatus.SC_OK);

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/HttpUtilsTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/HttpUtilsTestCase.java
@@ -1,0 +1,65 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.livereload.internal.util;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.jboss.tools.livereload.core.internal.util.HttpUtils;
+import org.junit.Test;
+
+/**
+ * @author xcoulon
+ *
+ */
+public class HttpUtilsTestCase {
+
+	@Test
+	public void shouldAcceptSimpleType() {
+		// pre-condition
+		final String acceptType = "text/html";
+		// operation
+		final boolean isHtmlContentType = HttpUtils.isHtmlContentType(acceptType);
+		// verification
+		assertThat(isHtmlContentType).isTrue();
+	}
+
+	@Test
+	public void shouldAcceptMultipleTypesWithQualityFactors() {
+		// pre-condition
+		final String acceptType = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+		// operation
+		final boolean isHtmlContentType = HttpUtils.isHtmlContentType(acceptType);
+		// verification
+		assertThat(isHtmlContentType).isTrue();
+	}
+
+	@Test
+	public void shouldAcceptSimpleTypeWithCharset() {
+		// pre-condition
+		final String acceptType = "text/html;charset=UTF-8";
+		// operation
+		final boolean isHtmlContentType = HttpUtils.isHtmlContentType(acceptType);
+		// verification
+		assertThat(isHtmlContentType).isTrue();
+	}
+	
+	@Test
+	public void shouldNotAcceptSimpleType() {
+		// pre-condition
+		final String acceptType = "text/css";
+		// operation
+		final boolean isHtmlContentType = HttpUtils.isHtmlContentType(acceptType);
+		// verification
+		assertThat(isHtmlContentType).isFalse();
+	}
+	
+}


### PR DESCRIPTION
Better checking the accepted types (in HTTP request header). In particular, dealing with charsets and quality factors
(located after a comma ';' character in the given Accept header)
