### PR TITLE
JBIDE-14955 - "Open In>Web Browser via LiveReload Server/QRCode" should be enabled even if LR server is stopped or missing

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
@@ -50,7 +50,7 @@ public class JettyServerRunner implements Runnable {
 				return runner.isStarted();
 			}
 		};
-		if (TimeoutUtils.timeout(monitor, 5, TimeUnit.SECONDS)) {
+		if (TimeoutUtils.timeout(monitor, 15, TimeUnit.SECONDS)) {
 			Logger.error("Failed to start " + jettyServer + " within expected time (reason: timeout)");
 			// attempt to stop what can be stopped.
 			stop(runner);

--- a/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadProxyEnablementTester.java
+++ b/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadProxyEnablementTester.java
@@ -34,8 +34,7 @@ public class OpenInWebBrowserViaLiveReloadProxyEnablementTester extends Property
 			return false;
 		}
 		final IServer appServer = appModule.getServer();
-		final boolean liveReloadProxyServerExists = (WSTUtils.findLiveReloadProxyServer(appModule.getServer()) != null);
-		return appServer != null && WSTUtils.isServerStarted(appServer) && liveReloadProxyServerExists;
+		return appServer != null && WSTUtils.isServerStarted(appServer);
 	}
 
 }

--- a/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadUtils.java
+++ b/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadUtils.java
@@ -175,6 +175,8 @@ public class OpenInWebBrowserViaLiveReloadUtils {
 		final URL url = computeURL(module);
 		if (url != null) {
 			PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(url);
+		} else {
+			Logger.warn("Unable to open the selected module '" + module.getModule()[0].getName() + "' in an external browser.");
 		}
 	}
 


### PR DESCRIPTION
Removed the 'proxy exists' check in the command enablement tester
Also added a little more time to allow for LiveReload startup (5sec seems sometimes a bit short)
Display a warning if 'Open In Web Browser' cannot be performed.
