### PR TITLE
JBIDE-14974 - Build failures on Jenkins

### DIFF
--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/AbstractCommonTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/AbstractCommonTestCase.java
@@ -138,6 +138,7 @@ public abstract class AbstractCommonTestCase {
 	}
 	
 	@Before
+	@After
 	public void stopandDestroyAllServers() throws CoreException, InterruptedException, ExecutionException, TimeoutException {
 		for(IServer server : ServerCore.getServers()) {
 			if(server.getServerState() != IServer.STATE_STOPPED) {

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/WSTUtilsTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/WSTUtilsTestCase.java
@@ -212,6 +212,7 @@ public class WSTUtilsTestCase extends AbstractCommonTestCase {
 		job.schedule();
 		job.join();
 		// verification
+		assertThat(job.getResult().isOK()).isTrue();
 		assertThat(liveReloadServer.getServerState()).isEqualTo(IServer.STATE_STARTED);
 	}
 


### PR DESCRIPTION
It _might_ be due to a previous test that started an LR server an left it running.
the PR consists in adding the @After annotation on the base method that stops
and deletes all servers before now also _and after_ each test.
