### PR TITLE
JBIDE-14974 - Build failures on Jenkins

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
@@ -98,7 +98,7 @@ public class JettyServerRunner implements Runnable {
 			if (!server.isStarted()) { 
 				Logger.debug("Starting {}...", server.getAttribute(NAME));
 				server.start();
-				server.join();
+				//server.join();
 			}
 		} catch (Exception e) {
 			Logger.error("Failed to start '" + server.getAttribute(NAME) + "'", e);

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/AbstractCommonTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/AbstractCommonTestCase.java
@@ -195,6 +195,10 @@ public abstract class AbstractCommonTestCase {
 	public static void stopServer(final IServer server, final int timeout, final TimeUnit unit) throws InterruptedException,
 			ExecutionException, TimeoutException {
 		LOGGER.info("Stopping server {}", server.getName());
+		if(!server.canStop().isOK()) {
+			LOGGER.warn("Cannot stop server {}, current state={}", server.getName(), server.getServerState());
+			return;
+		}
 		server.stop(true);
 		Future<?> future = Executors.newSingleThreadExecutor().submit(new Runnable() {
 


### PR DESCRIPTION
Removing the call to "server.joint()" in its own thread to avoid timeouts when trying to stop the
jetty server.
Also adding some logs if the server cannot be stopped (just for information..)
