### PR TITLE
JBIDE-14595 - LiveReload server should not display a "started" status if it failed to start

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
@@ -54,16 +54,24 @@ public class LiveReloadServer extends Server implements Subscriber {
 	 *            the LiveReload configuration to use.
 	 * @throws UnknownHostException
 	 */
-	public LiveReloadServer(final int websocketPort, final boolean enableProxyServer,
+	public LiveReloadServer(final String name, final int websocketPort, final boolean enableProxyServer,
 			final boolean allowRemoteConnections, final boolean enableScriptInjection) {
 		super();
 		this.websocketPort = websocketPort;
-		configure(websocketPort, enableProxyServer, allowRemoteConnections, enableScriptInjection);
+		configure(name, websocketPort, enableProxyServer, allowRemoteConnections, enableScriptInjection);
 	}
 
-	private void configure(final int websocketPort, final boolean enableProxyServer,
+	/**
+	 * Configure the Jetty Server with the given parameters
+	 * @param name the server name (same as the Server Adapter)
+	 * @param websocketPort the websockets port
+	 * @param enableProxyServer should proxy be enabled 
+	 * @param allowRemoteConnections should allow remote connections
+	 * @param enableScriptInjection should inject livereload.js script in returned HTML pages
+	 */
+	private void configure(final String name, final int websocketPort, final boolean enableProxyServer,
 			final boolean allowRemoteConnections, final boolean enableScriptInjection) {
-		setAttribute(JettyServerRunner.NAME, "LiveReload-Server");
+		setAttribute(JettyServerRunner.NAME, name);
 		websocketConnector = new SelectChannelConnector();
 		if (!allowRemoteConnections) {
 			websocketConnector.setHost("localhost");

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
@@ -130,15 +130,19 @@ public class LiveReloadServerBehaviour extends ServerBehaviourDelegate implement
 			}
 			final boolean allowRemoteConnections = isRemoteConnectionsAllowed();
 			final boolean enableScriptInjection = isScriptInjectionEnabled();
-			this.liveReloadServer = new LiveReloadServer(websocketPort, true, allowRemoteConnections,
+			this.liveReloadServer = new LiveReloadServer(server.getName(), websocketPort, true, allowRemoteConnections,
 					enableScriptInjection);
 			this.liveReloadServerRunnable = JettyServerRunner.start(liveReloadServer);
-			// listen to file changes in the workspace
-			addWorkspaceResourceChangeListener();
-			// listen to server lifecycles
-			addServerLifeCycleListener();
-			// set the server status to "Started"
-			setServerStarted();
+			if(!this.liveReloadServerRunnable.isSuccessfullyStarted()) { 
+				setServerStopped();
+			} else {
+				// listen to file changes in the workspace
+				addWorkspaceResourceChangeListener();
+				// listen to server lifecycles
+				addServerLifeCycleListener();
+				// set the server status to "Started"
+				setServerStarted();
+			}
 		} catch (TimeoutException e) {
 			setServerStopped();
 			throw new CoreException(new Status(IStatus.ERROR, JBossLiveReloadCoreActivator.PLUGIN_ID, e.getMessage(), e));

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/Logger.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/Logger.java
@@ -15,6 +15,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.jboss.tools.livereload.core.internal.JBossLiveReloadCoreActivator;
@@ -65,13 +66,16 @@ public final class Logger {
 	 * @param t
 	 *            the throwable cause
 	 */
-	public static void error(final String message, final Throwable t) {
+	public static IStatus error(final String message, final Throwable t) {
 		if (JBossLiveReloadCoreActivator.getDefault() != null) {
+			final Status status = new Status(Status.ERROR, JBossLiveReloadCoreActivator.PLUGIN_ID, message, t);
 			JBossLiveReloadCoreActivator.getDefault().getLog()
-					.log(new Status(Status.ERROR, JBossLiveReloadCoreActivator.PLUGIN_ID, message, t));
+					.log(status);
+			return status;
 		} else {
 			// at least write in the .log file
 			t.printStackTrace();
+			return null;
 		}
 	}
 

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
@@ -115,9 +115,9 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 	 * @throws InterruptedException
 	 * 
 	 */
-	private void createAndLaunchLiveReloadServer(final boolean injectScript)
+	private IServer createAndLaunchLiveReloadServer(final String serverName, final boolean injectScript)
 			throws CoreException, InterruptedException, ExecutionException, TimeoutException {
-		final IServer server = WSTUtils.createLiveReloadServer(liveReloadServerPort,
+		final IServer server = WSTUtils.createLiveReloadServer(serverName, liveReloadServerPort,
 				injectScript, false);
 		liveReloadServerBehaviour = (LiveReloadServerBehaviour) WSTUtils.findServerBehaviour(server);
 		assertThat(liveReloadServerBehaviour).isNotNull();
@@ -127,6 +127,19 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 
 		assertThat(SocketUtil.isPortInUse(liveReloadServerPort)).isFalse();
 		startServer(liveReloadServer, 60, TimeUnit.SECONDS);
+		return server;
+	}
+
+	/**
+	 * @throws CoreException
+	 * @throws TimeoutException
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 * 
+	 */
+	private IServer createAndLaunchLiveReloadServer(final boolean injectScript)
+			throws CoreException, InterruptedException, ExecutionException, TimeoutException {
+		return createAndLaunchLiveReloadServer("LiveReload Test Server at localhost", injectScript);
 	}
 	
 	/**
@@ -739,6 +752,18 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 		int newProxyPort = liveReloadServerBehaviour.getProxyServers().get(httpPreviewServer).getConnectors()[0]
 				.getPort();
 		assertThat(proxyPort).isEqualTo(newProxyPort);
+	}
+	
+	@Test
+	public void shouldNotStartIfPortAlreadyInUse() throws CoreException, InterruptedException, ExecutionException, TimeoutException {
+		// pre-condition: create a first server (no need for script injection)
+		final IServer firstServer = createAndLaunchLiveReloadServer("Server 1", false);
+		assertThat(firstServer.getServerState()).isEqualTo(IServer.STATE_STARTED);
+		// operation: create a second server (no need for script injection
+		// either) and attempt to start it on the same port -> should not start
+		final IServer secondServer = createAndLaunchLiveReloadServer("Server 2", false);
+		// verification
+		assertThat(secondServer.getServerState()).isEqualTo(IServer.STATE_STOPPED);
 	}
 
 }

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/DummyServer.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/DummyServer.java
@@ -1,0 +1,44 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.livereload.internal.util;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * A dummy server that will open a socket, just to make sure no one else (like LiveReload) can use it..
+ * @author xcoulon
+ *
+ */
+public class DummyServer {
+
+	public static void main(String[] args) throws IOException {
+		DummyServer server = new DummyServer(Integer.parseInt(args[0]));
+		server.start();
+	}
+
+	private final int portNumber; 
+	
+	/**
+	 * 
+	 */
+	public DummyServer(final int portNumber) {
+		this.portNumber = portNumber;
+	}
+
+	private void start() throws IOException {
+		ServerSocket serverSocket = new ServerSocket(portNumber);
+		serverSocket.accept();
+		
+	}
+	
+}

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/WSTUtilsTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/WSTUtilsTestCase.java
@@ -207,10 +207,9 @@ public class WSTUtilsTestCase extends AbstractCommonTestCase {
 		// pre-condition
 		final IServer liveReloadServer = WSTUtils.createLiveReloadServer(SocketUtil.findUnusedPort(50000, 60000),
 				false, false);
+		assertThat(liveReloadServer.getServerState()).isEqualTo(IServer.STATE_STOPPED);
 		// operation
-		final Job job = WSTUtils.startOrRestartServer(liveReloadServer, 30, TimeUnit.SECONDS);
-		job.schedule();
-		job.join();
+		final Job job = startServer(liveReloadServer, 30, TimeUnit.SECONDS);
 		// verification
 		assertThat(job.getResult().isOK()).isTrue();
 		assertThat(liveReloadServer.getServerState()).isEqualTo(IServer.STATE_STARTED);


### PR DESCRIPTION
Properly setting server state back to 'stopped' if underyling Jetty server could not start (eg: address already in use)
Added a JUnit test FTW ;-)
