### PR TITLE
JBIDE-14595 - LiveReload server should not display a "started" status if it failed to start

### DIFF
--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
@@ -125,7 +125,6 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 		assertThat(liveReloadServer).isNotNull();
 		assertThat(liveReloadServer.canStart(ILaunchManager.RUN_MODE).isOK()).isTrue();
 
-		assertThat(SocketUtil.isPortInUse(liveReloadServerPort)).isFalse();
 		startServer(liveReloadServer, 60, TimeUnit.SECONDS);
 		return server;
 	}


### PR DESCRIPTION
Removing check on Free Port b/c it doesn't work on MacOSX but does on Linux, and in a particular test case,
we need to attempt to start 2 servers on the same port
