### PR TITLE
JBIDE-14994 - Page differences between page displayed via LiveReload and original page sent from server

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/lib/.gitkeeper
+++ b/plugins/org.jboss.tools.livereload.core/lib/.gitkeeper
@@ -1,0 +1,1 @@
+Please do not remove.

--- a/plugins/org.jboss.tools.livereload.core/pom.xml
+++ b/plugins/org.jboss.tools.livereload.core/pom.xml
@@ -61,7 +61,7 @@
 						<fileset>
 							<directory>lib</directory>
 							<includes>
-								<include>**/*</include>
+								<include>**/*.jar</include>
 							</includes>
 						</fileset>
 					</filesets>

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/JBossLiveReloadCoreActivator.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/JBossLiveReloadCoreActivator.java
@@ -13,7 +13,7 @@ import org.osgi.framework.BundleContext;
 public class JBossLiveReloadCoreActivator extends AbstractUIPlugin {
 
 	// The plug-in ID
-	public static final String PLUGIN_ID = "org.jboss.tools.livereload"; //$NON-NLS-1$
+	public static final String PLUGIN_ID = "org.jboss.tools.livereload.core"; //$NON-NLS-1$
 
 	// The shared instance
 	private static JBossLiveReloadCoreActivator plugin;

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/ApplicationsProxyServlet.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/ApplicationsProxyServlet.java
@@ -40,7 +40,7 @@ public class ApplicationsProxyServlet extends ProxyServlet {
 	@Override
 	protected HttpURI proxyHttpURI(HttpServletRequest request, String uri) throws MalformedURLException {
 		try {
-			final URI requestURI = new URI(request.getRequestURI());
+			final URI requestURI = new URI(uri);
 			final URI originalURI = new URI(request.getScheme(), requestURI.getUserInfo(), request.getServerName(), request.getLocalPort(), requestURI.getPath(), requestURI.getQuery(), requestURI.getFragment());
 			final String proxiedURI = URIUtils.convert(originalURI).toHost(targetHost).toPort(targetPort);
 			return new HttpURI(proxiedURI);

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.jboss.tools.livereload.core.internal.JBossLiveReloadCoreActivator;
 import org.jboss.tools.livereload.core.internal.util.Logger;
 import org.jboss.tools.livereload.core.internal.util.TimeoutUtils;
 import org.jboss.tools.livereload.core.internal.util.TimeoutUtils.TaskMonitor;

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
@@ -123,7 +123,9 @@ public class LiveReloadServerBehaviour extends ServerBehaviourDelegate implement
 			// now, let's init and start the embedded jetty server from the
 			// server attributes
 			final IServer server = getServer();
-			websocketPort = server.getAttribute(LiveReloadLaunchConfiguration.WEBSOCKET_PORT, -1);
+			// retrieve the websocket port, use the default value if it was missing
+			websocketPort = server.getAttribute(LiveReloadLaunchConfiguration.WEBSOCKET_PORT, LiveReloadLaunchConfiguration.DEFAULT_WEBSOCKET_PORT);
+			
 			// fix the new default behaviour: proxy is now always enabled
 			if(!isProxyEnabled()) {
 				setProxyEnabled(true);

--- a/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
@@ -29,7 +29,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.wst.web,
  org.slf4j.api;bundle-version="1.6.4",
  ch.qos.logback.classic;bundle-version="1.0.0",
- ch.qos.logback.core;bundle-version="1.0.0"
+ ch.qos.logback.core;bundle-version="1.0.0",
+ org.eclipse.jetty.servlet
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServer.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServer.java
@@ -25,6 +25,8 @@ import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.jboss.tools.livereload.core.internal.server.jetty.JettyServerRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,9 +51,13 @@ public class PreviewServer extends Server {
 		addConnector(connector);
 		ResourceHandler resourceHandler = new ResourceHandler();
 		resourceHandler.setResourceBase(baseLocation);
+		
+		ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/foo");
+		context.addServlet(new ServletHolder(new QueryParamVerifierServlet()), "/bar");
 		LOGGER.info("serving {} on port {}", resourceHandler.getBaseResource(), port );
 		HandlerList handlers = new HandlerList();
-		handlers.setHandlers(new Handler[] { resourceHandler, new DefaultHandler() });
+		handlers.setHandlers(new Handler[] { resourceHandler, context, new DefaultHandler() });
 		setHandler(handlers);
 	}
 	

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/QueryParamVerifierServlet.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/QueryParamVerifierServlet.java
@@ -1,0 +1,29 @@
+package org.jboss.tools.livereload.test.previewserver;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class QueryParamVerifierServlet extends HttpServlet {
+
+	private static final long serialVersionUID = 8502427396225099738L;
+
+	/* (non-Javadoc)
+	 * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+	 */
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		if(request.getQueryString() != null && !request.getQueryString().isEmpty()) {
+			response.getOutputStream().write("OK :-)".getBytes());
+			response.setStatus(200);
+		} else {
+			response.getOutputStream().write("Expected query params :-(".getBytes());
+			response.setStatus(400);
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
Proxy server was not forwarding the full URI, it used to remove the QueryParams, which would cause the seam app on AS 7.1 to return 404
Added a test to verify that, using a dedicated Servlet in the Preview Server. This servlet will return a 400 error if the incoming request
did not contain query params.
