### PR TITLE
JBIDE-15317 - LiveReload script injection corrupted html encoding

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/JBossLiveReloadCoreActivator.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/JBossLiveReloadCoreActivator.java
@@ -68,6 +68,9 @@ public class JBossLiveReloadCoreActivator extends AbstractUIPlugin {
 
 	public InputStream getResourceContent(String path) throws IOException {
 		final URL resource = getBundle().getResource(path);
+		if(resource == null) {
+			return null;
+		}
 		return resource.openStream();
 	}
 }

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
@@ -36,8 +36,12 @@ public class LiveReloadProxyServer extends Server {
 	/**
 	 * Constructor
 	 * 
-	 * @param config
-	 *            the LiveReload configuration to use.
+	 * @param proxyPort
+ 	 * @param targetHost
+	 * @param targetPort
+	 * @param liveReloadPort
+	 * @param allowRemoteConnections
+	 * @param enableScriptInjection
 	 * @throws UnknownHostException
 	 */
 	public LiveReloadProxyServer(final int proxyPort, final String targetHost, final int targetPort, final int liveReloadPort, final boolean allowRemoteConnections,

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptInjectionFilter.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptInjectionFilter.java
@@ -14,6 +14,9 @@ package org.jboss.tools.livereload.core.internal.server.jetty;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -122,7 +125,8 @@ public class LiveReloadScriptInjectionFilter implements Filter {
 					returnedContentType);
 			final InputStream responseStream = responseWrapper.getResponseAsStream();
 			final char[] modifiedResponseContent = ScriptInjectionUtils.injectContent(responseStream, scriptContent);
-			responseWrapper.terminate(modifiedResponseContent);
+			final Charset charset = HttpUtils.getContentCharSet(returnedContentType, "UTF-8");
+			responseWrapper.terminate(modifiedResponseContent, charset);
 		}
 		// finalize the responseWrapper by copying the wrapper's
 		// outputstream into the response outputstream that will be returned
@@ -184,7 +188,8 @@ public class LiveReloadScriptInjectionFilter implements Filter {
 		public InputStream getResponseAsStream() throws IOException {
 			final byte[] byteArray = responseOutputStream.toByteArray();
 			responseOutputStream.close();
-			return IOUtils.toInputStream(new String(byteArray), getCharacterEncoding());
+			final String characterEncoding = getCharacterEncoding();
+			return IOUtils.toInputStream(new String(byteArray, characterEncoding), characterEncoding);
 		}
 
 		/**
@@ -192,16 +197,20 @@ public class LiveReloadScriptInjectionFilter implements Filter {
 		 * and adjust the 'content-length' response header as well (in case
 		 * content modification occurred in the response entity).
 		 * 
+		 * @param responseContent the content of the response.
+		 * @param encoding the ecnoding to use when writing the char[] content into the response's outputstream.
+		 * 
 		 * @throws IOException
 		 */
-		public void terminate(final char[] responseContent) throws IOException {
-			((HttpServletResponse) getResponse()).setHeader("Content-length", Integer.toString(responseContent.length));
-			IOUtils.write(responseContent, getResponse().getOutputStream());
-			// getResponse().getOutputStream().flush();
-			// getResponse().getOutputStream().close();
+		public void terminate(final char[] responseContent, final Charset charset) throws IOException {
+			// see http://mark.koli.ch/2009/09/remember-kids-an-http-content-length-is-the-number-of-bytes-not-the-number-of-characters.html
+			final CharBuffer charBuffer = CharBuffer.wrap(responseContent);
+			final ByteBuffer byteBuffer = charset.encode(charBuffer);
+			((HttpServletResponse) getResponse()).setHeader("Content-length", Integer.toString(byteBuffer.array().length));
+			IOUtils.write(responseContent, getResponse().getOutputStream(), charset.name()); 
 			responseOutputStream.close();
 		}
-
+		
 		/**
 		 * Writes the content of the internal and temporary
 		 * {@link ByteArrayOutputStream} into the wrapped

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.livereload.core.internal.server.jetty;
 
-import java.net.UnknownHostException;
 import java.util.EventObject;
 
 import org.eclipse.jetty.server.Server;
@@ -49,10 +48,11 @@ public class LiveReloadServer extends Server implements Subscriber {
 
 	/**
 	 * Constructor
-	 * 
-	 * @param config
-	 *            the LiveReload configuration to use.
-	 * @throws UnknownHostException
+	 * @param name the server name (appears in the Servers Views)
+	 * @param websocketPort the websocket port
+	 * @param enableProxyServer flag to enable the proxy server
+	 * @param allowRemoteConnections flag to allow remote connections
+	 * @param enableScriptInjection flag to enable script injection
 	 */
 	public LiveReloadServer(final String name, final int websocketPort, final boolean enableProxyServer,
 			final boolean allowRemoteConnections, final boolean enableScriptInjection) {

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadLaunchConfiguration.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadLaunchConfiguration.java
@@ -40,6 +40,7 @@ public class LiveReloadLaunchConfiguration implements ILaunchConfigurationDelega
 
 	public static final int DEFAULT_WEBSOCKET_PORT = 35729;
 
+
 	@Override
 	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
 			throws CoreException {

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
@@ -125,7 +125,6 @@ public class LiveReloadServerBehaviour extends ServerBehaviourDelegate implement
 			final IServer server = getServer();
 			// retrieve the websocket port, use the default value if it was missing
 			websocketPort = server.getAttribute(LiveReloadLaunchConfiguration.WEBSOCKET_PORT, LiveReloadLaunchConfiguration.DEFAULT_WEBSOCKET_PORT);
-			
 			// fix the new default behaviour: proxy is now always enabled
 			if(!isProxyEnabled()) {
 				setProxyEnabled(true);

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/HttpUtils.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/HttpUtils.java
@@ -11,6 +11,8 @@
 
 package org.jboss.tools.livereload.core.internal.util;
 
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.StringTokenizer;
 
 /**
@@ -45,7 +47,7 @@ public class HttpUtils {
 		if (acceptedContentTypes == null) {
 			return false;
 		}
-		// first, let's remove everything after the coma character
+		// first, let's remove everything behind the comma character
 		int location = acceptedContentTypes.indexOf(";");
 		final String contentTypes = (location != -1) ? acceptedContentTypes.substring(0, location):acceptedContentTypes; 
 		// now, let's analyze each type
@@ -58,6 +60,38 @@ public class HttpUtils {
 			}
 		}
 		return false;
+	}
+	
+	/**
+	 * Returns the {@link Charset} from the given content-type.
+	 * 
+	 * @param contentType
+	 *            the given content type that may contain some ";charset=...".
+	 * @param defaultCharsetName
+	 *            the name of the default charset to return in case when the given
+	 *            contentType would be null or would not contain any specific
+	 *            charset. If this name cannot be resolved into a valid charset, then "UTF-8" is used.
+	 * @return the value of the "charset" token in the given contentType, or
+	 *         the given defaultCharsetName, or "UTF-8" as a last resort.
+	 */
+	public static Charset getContentCharSet(final String contentType, final String defaultCharsetName) {
+		if(contentType != null) { 
+			final StringTokenizer stk = new StringTokenizer(contentType, ";");
+			while(stk.hasMoreTokens()) {
+				final String token = stk.nextToken().toLowerCase().replace(" ", "");
+				if(token.startsWith("charset=")) { 
+					final StringTokenizer tokenSplitter = new StringTokenizer(token, "=");
+					tokenSplitter.nextToken(); // skip the 'charset' part as we already know it
+					final String value = tokenSplitter.hasMoreTokens()? tokenSplitter.nextToken() : null;
+					return Charset.forName(value.toUpperCase());
+				}
+			}
+		}
+		try {
+			return Charset.forName(defaultCharsetName);
+		} catch(UnsupportedCharsetException e) {
+			return Charset.forName("UTF-8");
+		}
 	}
 
 }

--- a/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/configuration/LiveReloadServerConfigurationMessages.java
+++ b/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/configuration/LiveReloadServerConfigurationMessages.java
@@ -19,7 +19,7 @@ public class LiveReloadServerConfigurationMessages extends NLS {
 
 	public static String WEBSOCKET_SERVER_PORT_LABEL;
 	public static String WEBSOCKET_SERVER_PORT_COMMAND;
-	
+
 	public static String PROXY_SERVER_CONFIGURATION_TITLE;
 	public static String PROXY_CONFIGURATION_DESCRIPTION;
 	

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.0.Alpha1-SNAPSHOT</version>
+		<version>4.1.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>livereload</artifactId>

--- a/tests/org.jboss.tools.livereload.test/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.jboss.tools.livereload.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+encoding//projects/sample-static-site/WebContent/chinese.html=UTF-8
+encoding//src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java=UTF-8

--- a/tests/org.jboss.tools.livereload.test/projects/sample-static-site/WebContent/chinese.html
+++ b/tests/org.jboss.tools.livereload.test/projects/sample-static-site/WebContent/chinese.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    中文
+  </body>
+</html>

--- a/tests/org.jboss.tools.livereload.test/src/chinese.html
+++ b/tests/org.jboss.tools.livereload.test/src/chinese.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    中文
+  </body>
+</html>

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/HttpUtilsTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/HttpUtilsTestCase.java
@@ -13,6 +13,8 @@ package org.jboss.tools.livereload.internal.util;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.nio.charset.Charset;
+
 import org.jboss.tools.livereload.core.internal.util.HttpUtils;
 import org.junit.Test;
 
@@ -62,4 +64,33 @@ public class HttpUtilsTestCase {
 		assertThat(isHtmlContentType).isFalse();
 	}
 	
+	@Test
+	public void shouldExtractCharset() {
+		// pre-condition
+		final String contentType = "text/html; charset=UTF-8";
+		// operation
+		final Charset charset = HttpUtils.getContentCharSet(contentType, "ISO-8859-1");
+		// verification
+		assertThat(charset.name()).isEqualTo("UTF-8");
+	}
+	
+	@Test
+	public void shouldReturnDefaultCharset() {
+		// pre-condition
+		final String contentType = "text/css";
+		// operation
+		final Charset charset = HttpUtils.getContentCharSet(contentType, "ISO-8859-1");
+		// verification
+		assertThat(charset.name()).isEqualTo("ISO-8859-1");
+	}
+
+	@Test
+	public void shouldReturnUTF8Charset() {
+		// pre-condition
+		final String contentType = "text/css";
+		// operation
+		final Charset charset = HttpUtils.getContentCharSet(contentType, "foobar");
+		// verification
+		assertThat(charset.name()).isEqualTo("UTF-8");
+	}
 }

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/ScriptInjectionUtilsTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/ScriptInjectionUtilsTestCase.java
@@ -14,7 +14,7 @@ package org.jboss.tools.livereload.internal.util;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.fest.assertions.Assertions;
+import static org.fest.assertions.Assertions.*;
 import org.jboss.tools.livereload.core.internal.util.ScriptInjectionUtils;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ public class ScriptInjectionUtilsTestCase {
 		// operation
 		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
 		// verifications
-		Assertions.assertThat(new String(modifiedContent)).contains(addition + "</body>");
+		assertThat(new String(modifiedContent)).contains(addition + "</body>");
 	}
 
 	@Test
@@ -43,7 +43,20 @@ public class ScriptInjectionUtilsTestCase {
 		// operation
 		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
 		// verifications
-		Assertions.assertThat(new String(modifiedContent)).doesNotContain(addition + "</body>");
+		assertThat(new String(modifiedContent)).doesNotContain(addition + "</body>");
 	}
+	
+	@Test
+	public void shouldInjectScriptAtEndOfChineseBody() throws IOException {
+		// pre-conditions
+		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("chinese.html");
+		final String addition = "<script src='foo!'/>";
+		// operation
+		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
+		// verifications
+		assertThat(new String(modifiedContent)).contains(addition + "</body>");
+		assertThat(new String(modifiedContent)).doesNotContain("???");
+	}
+
 
 }

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServer.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServer.java
@@ -26,8 +26,10 @@ import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.jboss.tools.livereload.core.internal.server.jetty.JettyServerRunner;
+import org.jboss.tools.livereload.core.internal.server.jetty.WorkspaceFileServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,12 +54,15 @@ public class PreviewServer extends Server {
 		ResourceHandler resourceHandler = new ResourceHandler();
 		resourceHandler.setResourceBase(baseLocation);
 		
-		ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
-        context.setContextPath("/foo");
-		context.addServlet(new ServletHolder(new QueryParamVerifierServlet()), "/bar");
+		ServletHandler workspaceServletHandler = new ServletHandler();
+		workspaceServletHandler.addServletWithMapping(new ServletHolder(new WorkspaceFileServlet()), "/");
+		
+		ServletContextHandler fooHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        fooHandler.setContextPath("/foo");
+		fooHandler.addServlet(new ServletHolder(new QueryParamVerifierServlet()), "/bar");
 		LOGGER.info("serving {} on port {}", resourceHandler.getBaseResource(), port );
 		HandlerList handlers = new HandlerList();
-		handlers.setHandlers(new Handler[] { resourceHandler, context, new DefaultHandler() });
+		handlers.setHandlers(new Handler[] {fooHandler, workspaceServletHandler, new DefaultHandler() });
 		setHandler(handlers);
 	}
 	


### PR DESCRIPTION
Using explicitely a charset when reading local files.
Default charset used is UTF-8
Adding a combo in the server configuration editor to let the user choose her charset or use the Charset.defaultValue() if none is specified.
