### PR TITLE
JBIDE-15430 - Chrome regression because of invalid content-lenght returned with special characters

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptInjectionFilter.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptInjectionFilter.java
@@ -207,7 +207,7 @@ public class LiveReloadScriptInjectionFilter implements Filter {
 			final CharBuffer charBuffer = CharBuffer.wrap(responseContent);
 			final ByteBuffer byteBuffer = charset.encode(charBuffer);
 			((HttpServletResponse) getResponse()).setHeader("Content-length", Integer.toString(byteBuffer.array().length));
-			IOUtils.write(responseContent, getResponse().getOutputStream(), charset.name()); 
+			getResponse().getOutputStream().write(byteBuffer.array());
 			responseOutputStream.close();
 		}
 		

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
@@ -346,10 +346,17 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 		assertThat(status).isEqualTo(HttpStatus.SC_OK);
 		// Read the response body.
 		String responseBody = method.getResponseBodyAsString();
+		byte[] rawResponseBody = method.getResponseBody();
 		assertThat(responseBody).contains(scriptContent);
 		LOGGER.debug(responseBody);
 		assertThat(responseBody).doesNotContain("??");
 		assertThat(responseBody).contains("中文");
+		//The Content-Length entity-header field indicates the size of the entity-body,
+		//in decimal number of OCTETs, sent to the recipient or, in the case of the HEAD
+		//method, the size of the entity-body that would have been sent had the request
+		//been a GET.
+		assertThat(rawResponseBody.length).isEqualTo(257);
+		assertThat(method.getResponseHeader("Content-Length").getValue()).isEqualTo("257");
 	}
 
 	@Test


### PR DESCRIPTION
Fixed the way the returned entity is written into the response outputstream
added a junit test to verify that the 'Content-Length' response header matches the actual response body (in byte[])
