### PR TITLE
JBIDE-15613 - Error: Failed to send reload command to browser

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptFileServlet.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadScriptFileServlet.java
@@ -38,7 +38,7 @@ public class LiveReloadScriptFileServlet extends HttpServlet {
 	protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
 		InputStream scriptContent = null;
 		try {
-			Logger.info("Serving embedded /livereload.js");
+			Logger.debug("Serving embedded /livereload.js");
 			final HttpServletResponse httpServletResponse = (HttpServletResponse) response;
 			scriptContent = JBossLiveReloadCoreActivator.getDefault().getResourceContent("/script/livereload.js");
 			if(scriptContent == null) {

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadWebSocketServlet.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadWebSocketServlet.java
@@ -11,6 +11,9 @@
 
 package org.jboss.tools.livereload.core.internal.server.jetty;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.jetty.websocket.WebSocket;
@@ -27,11 +30,24 @@ public class LiveReloadWebSocketServlet extends WebSocketServlet {
 	/** serialVersionUID */
 	private static final long serialVersionUID = 2515781694370015615L;
 
+	/** List of the LiveReloadWebSocket created by this LiveReloadWebSocketServlet. */
+	private final List<LiveReloadWebSocket> webSockets = new ArrayList<LiveReloadWebSocket>();
+	
 	@Override
 	public WebSocket doWebSocketConnect(HttpServletRequest request, String protocol) {
-		return new LiveReloadWebSocket((String) request.getHeader("User-Agent"), request.getRemoteAddr());
+		final LiveReloadWebSocket liveReloadWebSocket = new LiveReloadWebSocket((String) request.getHeader("User-Agent"), request.getRemoteAddr());
+		webSockets.add(liveReloadWebSocket);
+		return liveReloadWebSocket;
 	}
 	
-	
+	@Override
+	public void destroy() {
+		super.destroy();
+		for(LiveReloadWebSocket webSocket : webSockets) {
+			webSocket.destroy();
+		}
+		webSockets.clear();
+		
+	}
 
 }

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/EventService.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/EventService.java
@@ -48,15 +48,16 @@ public class EventService {
 	 */
 	public void publish(final EventObject event) {
 		if (this.subscribers.size() > 0) {
+			Logger.debug("Notifying {} client(s) of event {}", this.subscribers.size(), event.toString());
 			for (Entry<Subscriber, List<EventFilter>> entry: this.subscribers.entrySet()) {
 				final Subscriber subscriber = entry.getKey();
 				final List<EventFilter> filters = entry.getValue();
 				for(EventFilter filter : filters) {
 					if (filter.accept(event)) {
-						Logger.debug("Informing subscriber '{}' of {}", subscriber.getId(), event.getSource());
+						Logger.debug("Informing subscriber '{}' of {}", subscriber.getId(), event.toString());
 						subscriber.inform(event);
 					} else {
-						Logger.debug("Ignored event {} by subscriber {}", event, subscriber.getId());
+						Logger.trace("Ignored event {} by subscriber {}", event, subscriber.getId());
 					}
 				}
 			}

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/WSTUtils.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/WSTUtils.java
@@ -180,6 +180,7 @@ public class WSTUtils {
 		} catch (MalformedURLException e) {
 			Logger.error("Unable to parse URL '" + browserLocation + "'", e);
 		}
+		Logger.warn("Could not identify server from client location " + browserLocation);
 		return null;
 	}
 
@@ -219,7 +220,7 @@ public class WSTUtils {
 			}
 		}
 		// default assumption for unknown specific server type...
-		Logger.warn("Assuming that server '" + server.getName() + "' is running on port 8080. LiveReload may not work as expected if it is not the case.");
+		Logger.debug("Assuming that server '" + server.getName() + "' is running on port 8080. LiveReload may not work as expected if it is not the case.");
 		return 8080;
 	}
 

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
@@ -488,7 +488,7 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 				"Hello, LiveReload !");
 		Thread.sleep(200);
 		// verification: client should have been notified with a reload message
-		assertThat(client.isNotificationReceived()).isEqualTo(true);
+		assertThat(client.getNumberOfReloadNotifications()).isEqualTo(1);
 		// end
 		connection.close();
 	}
@@ -505,7 +505,7 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 				"Hello, LiveReload !");
 		Thread.sleep(200);
 		// verification: client should have been notified with a reload message
-		assertThat(client.isNotificationReceived()).isEqualTo(true);
+		assertThat(client.getNumberOfReloadNotifications()).isEqualTo(1);
 		assertThat(client.getReceivedNotification().contains(unknownServerLocation));
 		// end
 		connection.close();
@@ -526,7 +526,7 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 		((Server) httpPreviewServer).publish(IServer.PUBLISH_AUTO, new NullProgressMonitor());
 		Thread.sleep(200);
 		// verification: client should have been notified with a reload message
-		assertThat(client.isNotificationReceived()).isEqualTo(true);
+		assertThat(client.getNumberOfReloadNotifications()).isEqualTo(1);
 		assertThat(client.getReceivedNotification()).contains("http://localhost:" + httpPreviewPort);
 		// end
 		connection.close();
@@ -547,7 +547,7 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 		((Server) httpPreviewServer).publish(IServer.PUBLISH_AUTO, new NullProgressMonitor());
 		Thread.sleep(200);
 		// verification: client should have been notified with a reload message
-		assertThat(client.isNotificationReceived()).isEqualTo(true);
+		assertThat(client.getNumberOfReloadNotifications()).isEqualTo(1);
 		assertThat(client.getReceivedNotification()).doesNotContain("http://localhost:" + this.liveReloadServerPort);
 		// end
 		connection.close();
@@ -567,7 +567,7 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 				"Hello, LiveReload !");
 		Thread.sleep(200);
 		// verification: client should have been notified with a reload message
-		assertThat(client.isNotificationReceived()).isEqualTo(false);
+		assertThat(client.getNumberOfReloadNotifications()).isEqualTo(0);
 		// end
 	}
 

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadTestClient.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadTestClient.java
@@ -17,7 +17,7 @@ public class LiveReloadTestClient implements WebSocket.OnTextMessage {
 	private final Properties livereloadMessages;
 	private Connection connection = null;
 	private final String location;
-	private boolean notificationReceived;
+	private int reloadNotificationsCounter = 0;
 	private String receivedNotification;
 	
 	public LiveReloadTestClient(final String location) throws IOException {
@@ -54,7 +54,7 @@ public class LiveReloadTestClient implements WebSocket.OnTextMessage {
 			sendMessage(urlCommand);
 		} else if(message.contains("\"command\":\"reload\"")) {
 			LOGGER.info("*** 'reload' command received ***");
-			this.notificationReceived = true;
+			this.reloadNotificationsCounter++;
 			receivedNotification = message;
 		}
 	}
@@ -71,10 +71,10 @@ public class LiveReloadTestClient implements WebSocket.OnTextMessage {
 	}
 
 	/**
-	 * @return the notificationReceived
+	 * @return the reloadNotificationsCounter
 	 */
-	public boolean isNotificationReceived() {
-		return notificationReceived;
+	public int getNumberOfReloadNotifications() {
+		return reloadNotificationsCounter;
 	}
 
 	public String getReceivedNotification() {

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServerBehaviour.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServerBehaviour.java
@@ -13,6 +13,7 @@ package org.jboss.tools.livereload.test.previewserver;
 
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.wst.server.core.IServer;
@@ -31,7 +32,7 @@ public class PreviewServerBehaviour extends ServerBehaviourDelegate {
 	/** The LiveReloadServer that embeds a jetty server. */
 	private PreviewServer previewServer;
 	private JettyServerRunner previewServerRunnable;
-
+	
 	/**
 	 * Starts the {@link PreviewServer} which is responsable for the embedded
 	 * web/websocket/proxy server configuration and lifecycle
@@ -90,7 +91,19 @@ public class PreviewServerBehaviour extends ServerBehaviourDelegate {
 
 	@Override
 	public IStatus canPublish() {
-		return Status.CANCEL_STATUS;
+		return Status.OK_STATUS;
+	}
+
+	@Override
+	public IStatus publish(int kind, IProgressMonitor monitor) {
+		setServerPublishState(IServer.PUBLISH_STATE_FULL);
+		IStatus status = super.publish(kind, monitor);
+		try {
+			Thread.sleep(1000);
+		} catch (InterruptedException e) {
+		}
+		setServerPublishState(IServer.PUBLISH_STATE_NONE);
+		return status;
 	}
 
 	public void setServerStarting() {

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServerDelegate.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/test/previewserver/PreviewServerDelegate.java
@@ -51,5 +51,7 @@ private final List<IProject> projects = new ArrayList<IProject>();
 	public void addProject(final IProject project) {
 		projects.add(project);
 	}
+	
+	
 
 }


### PR DESCRIPTION
Problem was that the ServerListener would send too many notifications
when a module would be published. Once the browser received the first
notification, it would refresh the page, which would close the current
websocket. Further messages for the same module publication would be sent
by the plugin, but one of them would fail to be delivered because the connection
would be closed.

Modified the JUnit test and HTTP Preview Server to reproduce the multiple events
and assert that only one notification is sent.
Adjusted some log messages as well.
