### PR TITLE
JBIDE-15127 - localhost seems hardcoded in livereload

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
@@ -29,13 +29,17 @@ import org.eclipse.jetty.servlet.ServletHolder;
  */
 public class LiveReloadProxyServer extends Server {
 
+	/** The underlying connector. */
 	private SelectChannelConnector connector;
 
+	/** network settings. */
+	private final String proxyHost, targetHost;
 	private final int proxyPort, targetPort;
 
 	/**
 	 * Constructor
 	 * 
+	 * @param proxyHost
 	 * @param proxyPort
  	 * @param targetHost
 	 * @param targetPort
@@ -44,20 +48,27 @@ public class LiveReloadProxyServer extends Server {
 	 * @param enableScriptInjection
 	 * @throws UnknownHostException
 	 */
-	public LiveReloadProxyServer(final int proxyPort, final String targetHost, final int targetPort, final int liveReloadPort, final boolean allowRemoteConnections,
+	public LiveReloadProxyServer(final String proxyHost, final int proxyPort, final String targetHost, final int targetPort, final int liveReloadPort, final boolean allowRemoteConnections,
 			final boolean enableScriptInjection) {
 		super();
+		this.proxyHost = proxyHost;
 		this.proxyPort = proxyPort;
+		this.targetHost = targetHost;
 		this.targetPort = targetPort;
-		configure(proxyPort, targetHost, targetPort, liveReloadPort, allowRemoteConnections, enableScriptInjection);
+		configure(proxyHost, proxyPort, targetHost, targetPort, liveReloadPort, allowRemoteConnections, enableScriptInjection);
 	}
 
-	private void configure(final int proxyPort, final String targetHost, final int targetPort, final int liveReloadPort, final boolean allowRemoteConnections,
+	private void configure(final String proxyHost, final int proxyPort, final String targetHost, final int targetPort, final int liveReloadPort, final boolean allowRemoteConnections,
 			final boolean enableScriptInjection) {
 		setAttribute(JettyServerRunner.NAME, "LiveReload-Proxy-Server-" + proxyPort + ":" + targetPort);
 		final SelectChannelConnector connector = new SelectChannelConnector();
+		// restrict access to clients on the same host
 		if (!allowRemoteConnections) {
-			connector.setHost("localhost");
+			connector.setHost(proxyHost);
+		} 
+		// allow remote connections
+		else {
+			connector.setHost(null);
 		}
 		connector.setPort(proxyPort);
 		connector.setMaxIdleTime(0);
@@ -83,6 +94,13 @@ public class LiveReloadProxyServer extends Server {
 	}
 	
 	/**
+	 * @return the proxyHost
+	 */
+	public String getProxyHost() {
+		return proxyHost;
+	}
+	
+	/**
 	 * @return the proxyPort
 	 */
 	public int getProxyPort() {
@@ -96,13 +114,16 @@ public class LiveReloadProxyServer extends Server {
 		return targetPort;
 	}
 
+	/**
+	 * @return the targetHost
+	 */
+	public String getTargetHost() {
+		return targetHost;
+	}
+	
 	@Override
 	public String toString() {
 		return "Proxy Server (" + proxyPort + " -> " + targetPort + ")";
-	}
-
-	public String getProxyHost() {
-		return "localhost";
 	}
 
 }

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
@@ -44,6 +44,8 @@ public class LiveReloadServer extends Server implements Subscriber {
 
 	private final int websocketPort;
 
+	private final String hostname;
+
 	private int connectedClients = 0;
 
 	/**
@@ -54,11 +56,12 @@ public class LiveReloadServer extends Server implements Subscriber {
 	 * @param allowRemoteConnections flag to allow remote connections
 	 * @param enableScriptInjection flag to enable script injection
 	 */
-	public LiveReloadServer(final String name, final int websocketPort, final boolean enableProxyServer,
+	public LiveReloadServer(final String name, final String hostname, final int websocketPort, final boolean enableProxyServer,
 			final boolean allowRemoteConnections, final boolean enableScriptInjection) {
 		super();
 		this.websocketPort = websocketPort;
-		configure(name, websocketPort, enableProxyServer, allowRemoteConnections, enableScriptInjection);
+		this.hostname = hostname;
+		configure(name, hostname, websocketPort, enableProxyServer, allowRemoteConnections, enableScriptInjection);
 	}
 
 	/**
@@ -69,12 +72,12 @@ public class LiveReloadServer extends Server implements Subscriber {
 	 * @param allowRemoteConnections should allow remote connections
 	 * @param enableScriptInjection should inject livereload.js script in returned HTML pages
 	 */
-	private void configure(final String name, final int websocketPort, final boolean enableProxyServer,
+	private void configure(final String name, final String hostname, final int websocketPort, final boolean enableProxyServer,
 			final boolean allowRemoteConnections, final boolean enableScriptInjection) {
 		setAttribute(JettyServerRunner.NAME, name);
 		websocketConnector = new SelectChannelConnector();
 		if (!allowRemoteConnections) {
-			websocketConnector.setHost("localhost");
+			websocketConnector.setHost(hostname);
 		}
 		websocketConnector.setStatsOn(true);
 		websocketConnector.setPort(websocketPort);
@@ -109,10 +112,14 @@ public class LiveReloadServer extends Server implements Subscriber {
 		return connectedClients;
 	}
 
+	public String getHost() {
+		return hostname;
+	}
+
 	public int getPort() {
 		return websocketPort;
 	}
-
+	
 	@Override
 	public String toString() {
 		return "LiveReload Server";

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
@@ -130,7 +130,7 @@ public class LiveReloadServerBehaviour extends ServerBehaviourDelegate implement
 			}
 			final boolean allowRemoteConnections = isRemoteConnectionsAllowed();
 			final boolean enableScriptInjection = isScriptInjectionEnabled();
-			this.liveReloadServer = new LiveReloadServer(server.getName(), websocketPort, true, allowRemoteConnections,
+			this.liveReloadServer = new LiveReloadServer(server.getName(), server.getHost(), websocketPort, true, allowRemoteConnections,
 					enableScriptInjection);
 			this.liveReloadServerRunnable = JettyServerRunner.start(liveReloadServer);
 			if(!this.liveReloadServerRunnable.isSuccessfullyStarted()) { 
@@ -325,8 +325,9 @@ public class LiveReloadServerBehaviour extends ServerBehaviourDelegate implement
 					// server attributes
 					final boolean allowRemoteConnections = isRemoteConnectionsAllowed();
 					final boolean enableScriptInjection = isScriptInjectionEnabled();
+					final String proxyHost = getProxyHost();
 					final int proxyPort = getProxyPort(startedServer);
-					final LiveReloadProxyServer proxyServer = new LiveReloadProxyServer(proxyPort, startedServer.getHost(), targetPort,
+					final LiveReloadProxyServer proxyServer = new LiveReloadProxyServer(proxyHost, proxyPort, startedServer.getHost(), targetPort,
 							websocketPort, allowRemoteConnections, enableScriptInjection);
 					proxyServers.put(startedServer, proxyServer);
 					final JettyServerRunner proxyRunner = JettyServerRunner.start(proxyServer);
@@ -338,9 +339,16 @@ public class LiveReloadServerBehaviour extends ServerBehaviourDelegate implement
 			}
 		}
 	}
+	
+	/**
+	 * @return the hostname configured for this LiveReload server
+	 */
+	private String getProxyHost() {
+		return getServer().getHost();
+	}
 
 	/**
-	 * Checks if thsi started server has already a configured proxy and returns
+	 * Checks if this started server has already a configured proxy and returns
 	 * the associated port if it is still free, or associate a new port if the
 	 * previous port is not avaiable anymore, or create a new port if none
 	 * existed before.

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/WSTUtils.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/WSTUtils.java
@@ -263,7 +263,7 @@ public class WSTUtils {
 	 */
 	public static IServer createLiveReloadServer(final int websocketPort, 
 			final boolean injectScript, final boolean allowRemoteConnections) throws CoreException {
-		return createLiveReloadServer("LiveReload Server at localhost", websocketPort, injectScript, allowRemoteConnections);
+		return createLiveReloadServer("LiveReload Server at localhost", "localhost", websocketPort, injectScript, allowRemoteConnections);
 	}
 	
 	/**
@@ -278,7 +278,7 @@ public class WSTUtils {
 	 * @return the server
 	 * @throws CoreException
 	 */
-	public static IServer createLiveReloadServer(final String serverName, final int websocketPort, 
+	public static IServer createLiveReloadServer(final String serverName, final String hostname, final int websocketPort, 
 			final boolean injectScript, final boolean allowRemoteConnections) throws CoreException {
 		IRuntimeType rt = ServerCore.findRuntimeType(LIVERELOAD_RUNTIME_TYPE);
 		IRuntimeWorkingCopy rwc = rt.createRuntime(null, null);
@@ -287,6 +287,7 @@ public class WSTUtils {
 		IServerWorkingCopy swc = (IServerWorkingCopy) st.createServer(serverName, null, null);
 		swc.setServerConfiguration(null);
 		swc.setName(serverName);
+		swc.setHost(hostname);
 		swc.setRuntime(runtime);
 		swc.setAttribute(LiveReloadLaunchConfiguration.WEBSOCKET_PORT, websocketPort);
 		swc.setAttribute(LiveReloadLaunchConfiguration.ENABLE_PROXY_SERVER, true);

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/JBossLiveReloadCoreActivatorTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/JBossLiveReloadCoreActivatorTestCase.java
@@ -100,7 +100,7 @@ public class JBossLiveReloadCoreActivatorTestCase extends AbstractCommonTestCase
 	 */
 	private IServer createLiveReloadServer(final String serverName, final boolean injectScript)
 			throws CoreException, InterruptedException, ExecutionException, TimeoutException {
-		final IServer server = WSTUtils.createLiveReloadServer(serverName, liveReloadServerPort,
+		final IServer server = WSTUtils.createLiveReloadServer(serverName, "localhost", liveReloadServerPort,
 				injectScript, false);
 		liveReloadServerBehaviour = (LiveReloadServerBehaviour) WSTUtils.findServerBehaviour(server);
 		assertThat(liveReloadServerBehaviour).isNotNull();


### PR DESCRIPTION
Using actual hostname configured in the LiveReload server to build
the URL that will be used by the browser.

Added JUnit test to check that it's not 'localhost' that is used.
