### PR TITLE
JBIDE-15805 - Livereload does not work with HTML files without <body>

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/ScriptInjectionUtils.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/ScriptInjectionUtils.java
@@ -26,9 +26,9 @@ import net.htmlparser.jericho.StreamedSource;
 public class ScriptInjectionUtils {
 	
 	/**
-	 * Inject the given 'addition' into the gievne source, just before the
-	 * <code>&lt;/body&gt;</code> ent tag. If no such end tag is found, the
-	 * return value equals the given source.
+	 * Inject the given 'addition' into the given source, just before the
+	 * <code>&lt;/head&gt;</code> end tag (or the <code>&lt;/body&gt;</code> end tag if not {@code head} element exists). 
+	 * If none pf those tags are found, the return value equals the given source.
 	 * 
 	 * @param source
 	 * @param addition
@@ -36,11 +36,17 @@ public class ScriptInjectionUtils {
 	 * @throws IOException
 	 */
 	public static char[] injectContent(final InputStream source, final String addition) throws IOException {
+		boolean tagFound = false;
 		final StreamedSource streamedSource = new StreamedSource(source);
 		CharArrayWriter writer = new CharArrayWriter();
 		for (Segment segment : streamedSource) {
-			if (segment instanceof EndTag && ((EndTag) segment).getName().equals("body")) {
+			if (segment instanceof EndTag && ((EndTag) segment).getName().equals("head")) {
 				writer.write(addition);
+				tagFound = true;
+			}
+			else if (!tagFound && segment instanceof EndTag && ((EndTag) segment).getName().equals("body")) {
+				writer.write(addition);
+				tagFound = true;
 			}
 			writer.write(segment.toString());
 		}

--- a/tests/org.jboss.tools.livereload.test/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.jboss.tools.livereload.test/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,4 @@
 eclipse.preferences.version=1
 encoding//projects/sample-static-site/WebContent/chinese.html=UTF-8
+encoding//src/chinese-no-head.html=UTF-8
 encoding//src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java=UTF-8

--- a/tests/org.jboss.tools.livereload.test/src/chinese-no-head.html
+++ b/tests/org.jboss.tools.livereload.test/src/chinese-no-head.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    中文
+  </body>
+</html>

--- a/tests/org.jboss.tools.livereload.test/src/no-body.html
+++ b/tests/org.jboss.tools.livereload.test/src/no-body.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Insert title here</title>
+</head>
+</html>

--- a/tests/org.jboss.tools.livereload.test/src/no-head.html
+++ b/tests/org.jboss.tools.livereload.test/src/no-head.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+foo
+</body>
+</html>

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/ScriptInjectionUtilsTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/ScriptInjectionUtilsTestCase.java
@@ -25,14 +25,14 @@ import org.junit.Test;
 public class ScriptInjectionUtilsTestCase {
 	
 	@Test
-	public void shouldInjectScriptAtEndOfBody() throws IOException {
+	public void shouldInjectScriptAtEndOfHead() throws IOException {
 		// pre-conditions
 		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("aerogear-index.txt");
 		final String addition = "<script src='foo!'/>";
 		// operation
 		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
 		// verifications
-		assertThat(new String(modifiedContent)).contains(addition + "</body>");
+		assertThat(new String(modifiedContent)).contains(addition + "</head>");
 	}
 
 	@Test
@@ -47,9 +47,21 @@ public class ScriptInjectionUtilsTestCase {
 	}
 	
 	@Test
-	public void shouldInjectScriptAtEndOfChineseBody() throws IOException {
+	public void shouldInjectScriptAtEndOfChineseHead() throws IOException {
 		// pre-conditions
 		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("chinese.html");
+		final String addition = "<script src='foo!'/>";
+		// operation
+		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
+		// verifications
+		assertThat(new String(modifiedContent)).contains(addition + "</head>");
+		assertThat(new String(modifiedContent)).doesNotContain("???");
+	}
+
+	@Test
+	public void shouldInjectScriptAtEndOfChineseBody() throws IOException {
+		// pre-conditions
+		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("chinese-no-head.html");
 		final String addition = "<script src='foo!'/>";
 		// operation
 		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
@@ -58,5 +70,27 @@ public class ScriptInjectionUtilsTestCase {
 		assertThat(new String(modifiedContent)).doesNotContain("???");
 	}
 
+	@Test
+	public void shouldInjectScriptInHeadWhenBodyElementMissing() throws IOException {
+		// pre-conditions
+		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("no-body.html");
+		final String addition = "<script src='foo!'/>";
+		// operation
+		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
+		// verifications
+		assertThat(new String(modifiedContent)).contains(addition + "</head>");
+	}
+
+	@Test
+	public void shouldInjectScriptInBodyWhenHeadElementMissing() throws IOException {
+		// pre-conditions
+		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("no-head.html");
+		final String addition = "<script src='foo!'/>";
+		// operation
+		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
+		// verifications
+		assertThat(new String(modifiedContent)).contains(addition + "</body>");
+	}
+	
 
 }


### PR DESCRIPTION
From now, the script is inserted at the end of the 'head' element (which is fine)
and if there's no such element, it is inserted at the end of the 'body' element.
