### PR TITLE
JBIDE-15966 Livereload does not work with HTML files without <html>

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/ScriptInjectionUtils.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/ScriptInjectionUtils.java
@@ -40,15 +40,22 @@ public class ScriptInjectionUtils {
 		final StreamedSource streamedSource = new StreamedSource(source);
 		CharArrayWriter writer = new CharArrayWriter();
 		for (Segment segment : streamedSource) {
-			if (segment instanceof EndTag && ((EndTag) segment).getName().equals("head")) {
+			if (segment instanceof EndTag && ((EndTag) segment).getName().equalsIgnoreCase("head")) { //$NON-NLS-1$
 				writer.write(addition);
 				tagFound = true;
 			}
-			else if (!tagFound && segment instanceof EndTag && ((EndTag) segment).getName().equals("body")) {
+			else if (!tagFound && segment instanceof EndTag && ((EndTag) segment).getName().equalsIgnoreCase("body")) { //$NON-NLS-1$
+				writer.write(addition);
+				tagFound = true;
+			}
+			else if (!tagFound && segment instanceof EndTag && ((EndTag) segment).getName().equalsIgnoreCase("html")) { //$NON-NLS-1$
 				writer.write(addition);
 				tagFound = true;
 			}
 			writer.write(segment.toString());
+		}
+		if(!tagFound){
+			writer.write(addition);
 		}
 		writer.close();
 		streamedSource.close();

--- a/tests/org.jboss.tools.livereload.test/src/no-head-body-html.html
+++ b/tests/org.jboss.tools.livereload.test/src/no-head-body-html.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Parargaph1</p>
+<a>link1</a>
+<p>Parargaph2</p>
+<a>link2</a>

--- a/tests/org.jboss.tools.livereload.test/src/no-head-body.html
+++ b/tests/org.jboss.tools.livereload.test/src/no-head-body.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<p>Parargaph1</p>
+<a>link1</a>
+<p>Parargaph2</p>
+<a>link2</a>
+</html>

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/ScriptInjectionUtilsTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/ScriptInjectionUtilsTestCase.java
@@ -92,5 +92,25 @@ public class ScriptInjectionUtilsTestCase {
 		assertThat(new String(modifiedContent)).contains(addition + "</body>");
 	}
 	
-
+	@Test
+	public void shouldInjectScriptInHtmlWhenHeadAndBodyElementsMissing() throws IOException {
+		// pre-conditions
+		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("no-head-body.html");
+		final String addition = "<script src='foo!'/>";
+		// operation
+		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
+		// verifications
+		assertThat(new String(modifiedContent)).contains(addition + "</html>");
+	}
+	
+	@Test
+	public void shouldInjectScriptInTheEndWhenHeadBodyHtmlElementsMissing() throws IOException {
+		// pre-conditions
+		final InputStream sourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("no-head-body-html.html");
+		final String addition = "<script src='foo!'/>";
+		// operation
+		final char[] modifiedContent = ScriptInjectionUtils.injectContent(sourceStream, addition);
+		// verifications
+		assertThat(new String(modifiedContent)).endsWith(addition);
+	}
 }


### PR DESCRIPTION
Updated ScriptInjectionUtils
1. if there is node "head" - insert script at the end of the "head"
2. if there is no "head" and there is "body" - insert script at the end of the "body"
3. if there is no "head" and "body"and there is "html" - insert script at the end of the "html"
4. if there is no "head", "body" and "html" - insert script at the end of file
