### PR TITLE
JBIDE-16435 - NPE when starting/stopping LiveReload server when server with unknown type already exist

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/wst/LiveReloadServerBehaviour.java
@@ -265,8 +265,10 @@ public class LiveReloadServerBehaviour extends ServerBehaviourDelegate implement
 	 * when a server is started and stopped
 	 */
 	private void removeServerLifeCycleListener() {
-		ServerCore.removeServerLifecycleListener(serverLifeCycleListener);
-		serverLifeCycleListener.stop();
+		if(serverLifeCycleListener != null) {
+			ServerCore.removeServerLifecycleListener(serverLifeCycleListener);
+			serverLifeCycleListener.stop();
+		}
 	}
 
 	/**

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/ServerLifeCycleListener.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/ServerLifeCycleListener.java
@@ -53,7 +53,7 @@ public class ServerLifeCycleListener implements IServerListener, IServerLifecycl
 
 	private void start() {
 		for (IServer server : ServerCore.getServers()) {
-			if (server.getServerType().getId().equals(WSTUtils.LIVERELOAD_SERVER_TYPE)) {
+			if (server.getServerType() == null || WSTUtils.LIVERELOAD_SERVER_TYPE.equals(server.getServerType().getId())) {
 				continue;
 			}
 			Logger.info("Adding ServerListener to existing server: " + server.getName());
@@ -67,7 +67,7 @@ public class ServerLifeCycleListener implements IServerListener, IServerLifecycl
 
 	public void stop() {
 		for (IServer server : ServerCore.getServers()) {
-			if (server.getServerType().getId().equals(WSTUtils.LIVERELOAD_SERVER_TYPE)) {
+			if (server.getServerType() == null || WSTUtils.LIVERELOAD_SERVER_TYPE.equals(server.getServerType().getId())) {
 				continue;
 			}
 			Logger.info("Removing ServerListener to existing server: " + server.getName());

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/WSTUtils.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/WSTUtils.java
@@ -164,7 +164,7 @@ public class WSTUtils {
 				}
 				// special case for LiveReload Server that may run Proxy Servers
 				// as well:
-				if (server.getServerType().getId().equals(LIVERELOAD_SERVER_TYPE)) {
+				if (server.getServerType() != null && server.getServerType().getId().equals(LIVERELOAD_SERVER_TYPE)) {
 					@SuppressWarnings("unchecked")
 					final Map<String, Integer> proxyPorts = (Map<String, Integer>) server.getAttribute(
 							LiveReloadServerBehaviour.PROXY_PORTS, Collections.emptyMap());


### PR DESCRIPTION
Preventing NPE when server runtime is null (ie, unknown) or ServerLifeCycleListener is null, too.
