### PR TITLE
JBIDE-20116 - Wrong IP address used when opening in web browser via l…

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/ApplicationsProxyServlet.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/ApplicationsProxyServlet.java
@@ -19,7 +19,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
-import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.proxy.ProxyServlet;
 import org.jboss.tools.livereload.core.internal.util.Logger;
 import org.jboss.tools.livereload.core.internal.util.URIUtils;
@@ -35,21 +34,26 @@ public class ApplicationsProxyServlet extends ProxyServlet {
 
 	private static final long serialVersionUID = -743475231540209788L;
 
+	private final String proxyHost;
+
 	private final int proxyPort;
 	
 	private final int targetPort;
 
 	private final String targetHost;
 
-	public ApplicationsProxyServlet(final int proxyPort, final String targetHost, final int targetPort) {
+	/**
+	 * Constructor
+	 * @param proxyHost name of the host running the proxy  
+	 * @param proxyPort port of the proxy
+	 * @param targetHost name or address of the host running the actual app server
+	 * @param targetPort port of the actual app server
+	 */
+	public ApplicationsProxyServlet(final String proxyHost, final int proxyPort, final String targetHost, final int targetPort) {
+		this.proxyHost = proxyHost;
 		this.proxyPort = proxyPort;
 		this.targetHost = targetHost;
 		this.targetPort = targetPort;
-	}
-	
-	@Override
-	public void service(ServletRequest request, ServletResponse response) throws ServletException, IOException {
-		super.service(request, response);
 	}
 	
 	@Override
@@ -70,10 +74,10 @@ public class ApplicationsProxyServlet extends ProxyServlet {
 	 * Customize the returned 'location' header to replace the app server port with the proxy port
 	 */
 	@Override
-	protected String filterResponseHeader(HttpServletRequest request, String headerName, String headerValue) {
+	public String filterResponseHeader(HttpServletRequest request, String headerName, String headerValue) {
 		if("Location".equals(headerName)) {
 			try {
-				return URIUtils.convert(headerValue).toPort(proxyPort);
+				return URIUtils.convert(headerValue).toHost(this.proxyHost).toPort(this.proxyPort);
 			} catch (URISyntaxException e) {
 				Logger.error("Failed to rewrite the 'Location' response header value '" + headerValue + "'",e);
 			}

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
@@ -76,7 +76,7 @@ public class LiveReloadProxyServer extends Server {
 
 		final ServletContextHandler context = new ServletContextHandler();
 		//context.setConnectorNames(new String[] { connector.getName() });
-		final ServletHolder proxyServletHolder = new ServletHolder(new ApplicationsProxyServlet(proxyPort, targetHost, targetPort));
+		final ServletHolder proxyServletHolder = new ServletHolder(new ApplicationsProxyServlet(proxyHost, proxyPort, targetHost, targetPort));
 		//proxyServletHolder.setAsyncSupported(true);
 		proxyServletHolder.setInitParameter("maxThreads", "256"); //$NON-NLS-1$ //$NON-NLS-2$
 		context.addServlet(proxyServletHolder, "/*");

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/core/internal/server/jetty/ApplicationProxyServletTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/core/internal/server/jetty/ApplicationProxyServletTestCase.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package org.jboss.tools.livereload.core.internal.server.jetty;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author xcoulon
+ *
+ */
+public class ApplicationProxyServletTestCase {
+	
+	@Test
+	public void shouldFilterLocation() throws Exception {
+		// given
+		final ApplicationsProxyServlet proxyServlet = new ApplicationsProxyServlet("localhost", 54321, "dockerhost", 8080);
+		final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		// when
+		final String locationHeaderValue = proxyServlet.filterResponseHeader(request, "Location", "http://dockerhost:8080/foo/bar/");
+		// then
+		assertThat(locationHeaderValue).isEqualTo("http://localhost:54321/foo/bar/");
+	}
+
+}

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/core/internal/server/jetty/package-info.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/core/internal/server/jetty/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+/**
+ * @author xcoulon
+ *
+ */
+package org.jboss.tools.livereload.core.internal.server.jetty;

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadServerTestCase.java
@@ -955,14 +955,15 @@ public class LiveReloadServerTestCase extends AbstractCommonTestCase {
 		assertThat(liveReloadServerBehaviour.getProxyServers().keySet()).contains(httpPreviewServer);
 		// operation: send a request and expect a 302 response with a 'Location' header using the proxy port
 		final NetworkConnector connector = (NetworkConnector) liveReloadServerBehaviour.getProxyServers().get(httpPreviewServer).getConnectors()[0];
+		final String proxyHost = connector.getHost();
 		final int proxyPort = connector.getPort();
 		final HttpClient client = new HttpClient();
-		final HttpMethod method = new GetMethod("http://localhost:" + proxyPort + "/foo/baz");
+		final HttpMethod method = new GetMethod("http://" + proxyHost + ":" + proxyPort + "/foo/baz");
 		method.setFollowRedirects(false);
 		final int status = client.executeMethod(method);
 		// verification
 		assertThat(status).isEqualTo(302);
-		assertThat(method.getResponseHeader("Location").getValue()).isEqualTo("http://localhost:" + proxyPort + "/foo/baz/");
+		assertThat(method.getResponseHeader("Location").getValue()).isEqualTo("http://" + proxyHost + ":" + proxyPort + "/foo/baz/");
 		
 	}
 }


### PR DESCRIPTION
…ivereload

Fixed the 'Location' response header rewriting by including the proxy host.