### PR TITLE
[JBIDE-20250] Enable m2e for o.j.t.livereload.core and o.j.t.livreload.ui

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/.classpath
+++ b/plugins/org.jboss.tools.livereload.core/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/jericho-html-3.3.jar"/>
-	<classpathentry kind="lib" path="lib/jackson-annotations-2.2.2.jar"/>
-	<classpathentry kind="lib" path="lib/jackson-core-2.2.2.jar"/>
-	<classpathentry kind="lib" path="lib/jackson-databind-2.2.2.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry exported="true" kind="lib" path="lib/jackson-annotations-2.2.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jackson-core-2.2.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jackson-databind-2.2.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jericho-html-3.3.jar"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.jboss.tools.livereload.core/.project
+++ b/plugins/org.jboss.tools.livereload.core/.project
@@ -20,8 +20,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/plugins/org.jboss.tools.livereload.ui/.classpath
+++ b/plugins/org.jboss.tools.livereload.ui/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/core-2.2.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry exported="true" kind="lib" path="lib/core-2.2.jar"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.jboss.tools.livereload.ui/.project
+++ b/plugins/org.jboss.tools.livereload.ui/.project
@@ -20,8 +20,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>


### PR DESCRIPTION
Fix enables m2e natures for cor and ui projects to trigger dependency
download after freshly clonned project is imported into eclipse
workspace