### PR TITLE
JBIDE-20335 - LiveReload logs errors on delete files

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadWebSocket.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadWebSocket.java
@@ -131,8 +131,10 @@ public class LiveReloadWebSocket implements Subscriber {
 				}
 				if(browserLocation.startsWith("file://")) {
 					final IProject project = ProjectUtils.extractProject(browserLocation);
-					eventService.subscribe(this, new WorkspaceResourceChangedEventFilter(project));
-					eventService.publish(new LiveReloadClientConnectedEvent(project));
+					if(project != null) {
+						eventService.subscribe(this, new WorkspaceResourceChangedEventFilter(project));
+						eventService.publish(new LiveReloadClientConnectedEvent(project));
+					}
 				} 
 				// register with a ServerResourcePublishedFilter unless the target server is the LiveReload server,
 				// in which case, the 
@@ -140,12 +142,15 @@ public class LiveReloadWebSocket implements Subscriber {
 					final IServer server = WSTUtils.extractServer(browserLocation);
 					if(server != null && WSTUtils.isLiveReloadServer(server)) {
 						final IProject project = ProjectUtils.findProjectFromResourceLocation(new Path(new URL(browserLocation).getFile()));
-						eventService.subscribe(this, new WorkspaceResourceChangedEventFilter(project));
-						eventService.publish(new LiveReloadClientConnectedEvent(project));
+						if(project != null) {
+							eventService.subscribe(this, new WorkspaceResourceChangedEventFilter(project));
+							eventService.publish(new LiveReloadClientConnectedEvent(project));
+						}
 					} else if(server != null) {
 						eventService.subscribe(this, new ServerResourcePublishedFilter(server));
 						eventService.publish(new LiveReloadClientConnectedEvent(server));
-					} else {
+					} 
+					else {
 						this.fallbackMode = true;
 						eventService.subscribe(this, new WorkspaceResourceChangedEventFallbackFilter());
 						eventService.publish(new LiveReloadClientConnectedEvent(browserLocation));

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/EventService.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/EventService.java
@@ -12,6 +12,7 @@ package org.jboss.tools.livereload.core.internal.service;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EventObject;
 import java.util.List;
 import java.util.Map;
@@ -80,14 +81,14 @@ public class EventService {
 	}
 
 	public void resetSubscribers() {
-		getSubscribers().clear();
+		this.subscribers.clear();
 	}
 
 	/**
 	 * @return the subscribers
 	 */
-	public Collection<Subscriber> getSubscribers() {
-		return subscribers.keySet();
+	public Map<Subscriber, List<EventFilter>> getSubscribers() {
+		return Collections.unmodifiableMap(this.subscribers);
 	}
 
 }

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadTestSocket.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/server/jetty/LiveReloadTestSocket.java
@@ -25,12 +25,13 @@ public class LiveReloadTestSocket {
 	private int reloadNotificationsCounter = 0;
 	private String receivedNotification;
 	
+	private boolean handshakeComplete = false;
+	
 	public LiveReloadTestSocket(final String location) throws IOException {
 		this.location = location;
 		livereloadMessages = new Properties();
 		final InputStream messagesStream = getClass().getResourceAsStream("messages.properties");
 		livereloadMessages.load(messagesStream);
-
 	}
  
 	@OnWebSocketClose
@@ -54,6 +55,7 @@ public class LiveReloadTestSocket {
 		if(message.contains("\"command\":\"hello\"")) {
 			final String urlCommand = livereloadMessages.getProperty("url_command").replace("{}", location);
 			sendMessage(urlCommand);
+			this.handshakeComplete = true;
 		} else if(message.contains("\"command\":\"reload\"")) {
 			LOGGER.info("*** 'reload' command received ***");
 			this.reloadNotificationsCounter++;
@@ -61,7 +63,7 @@ public class LiveReloadTestSocket {
 		}
 	}
 
-	public void sendMessage(final String message) {
+	private void sendMessage(final String message) {
 		if (session != null) {
 			try {
 				LOGGER.debug("Sending message {}", message);
@@ -72,6 +74,10 @@ public class LiveReloadTestSocket {
 		}
 	}
 
+	public boolean isHandshakeComplete() {
+		return handshakeComplete;
+	}
+	
 	/**
 	 * @return the reloadNotificationsCounter
 	 */


### PR DESCRIPTION
Prevent the NPE when the parent project for the given
resource cannot be found
Added JUnit test to cover that case.