### PR TITLE
JBIDE-20684 - Restarting Livereload server fails when it is in use

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadProxyServer.java
@@ -71,6 +71,7 @@ public class LiveReloadProxyServer extends Server {
 			connector.setHost(null);
 		}
 		connector.setPort(proxyPort);
+		connector.setReuseAddress(true);
 		//connector.setMaxIdleTime(0);
 		addConnector(connector);
 

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/LiveReloadServer.java
@@ -74,8 +74,7 @@ public class LiveReloadServer extends Server implements Subscriber {
 			final boolean allowRemoteConnections, final boolean enableScriptInjection) {
 		setAttribute(JettyServerRunner.NAME, name);
 		websocketConnector = new ServerConnector(this);
-		// see http://stackoverflow.com/questions/12352935/how-are-two-processes-listening-to-the-same-port-in-windows-7
-		websocketConnector.setReuseAddress(false); // prevent server to start on a used port.
+		websocketConnector.setReuseAddress(true);
 		if (!allowRemoteConnections) {
 			websocketConnector.setHost(hostname);
 		}

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/EventService.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/service/EventService.java
@@ -11,7 +11,6 @@
 package org.jboss.tools.livereload.core.internal.service;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EventObject;
 import java.util.List;


### PR DESCRIPTION
Using the ServerConnector#setReuseAddress(true) to reuse an
existing socket/connection just after server was closed
and avoid the BindException