### PR TITLE
JBIDE-21994 - Cannot show OpenShift 3 application via live reload

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.livereload.core;singleton:=true
 Bundle-Version: 1.3.1.qualifier
 Bundle-Activator: org.jboss.tools.livereload.core.internal.JBossLiveReloadCoreActivator
 Bundle-Vendor: JBoss by Red Hat
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.8.1",
  org.eclipse.core.databinding;bundle-version="1.4.1",
  org.junit;bundle-version="4.10.0";resolution:=optional,
@@ -29,16 +28,15 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jetty.proxy;bundle-version="[9.2.13,9.2.14)",
  org.apache.commons.io;bundle-version="2.0.1",
  org.jboss.tools.common;bundle-version="3.4.0",
- org.jboss.tools.common.ui;bundle-version="3.6.0",
  org.eclipse.debug.core;bundle-version="3.8.0",
  org.jboss.ide.eclipse.as.core;bundle-version="3.0.0",
- org.eclipse.ui.browser;bundle-version="3.4.200",
  org.eclipse.jst.server.tomcat.core;bundle-version="1.1.500",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.5.0",
  com.fasterxml.jackson.core.jackson-core;bundle-version="2.5.0",
  com.fasterxml.jackson.core.jackson-databind;bundle-version="2.5.0",
  org.apache.aries.spifly.dynamic.bundle;bundle-version="1.0.2",
- org.jboss.tools.usage;bundle-version="2.1.1"
+ org.jboss.tools.usage;bundle-version="2.1.1",
+ org.eclipse.core.commands
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/JBossLiveReloadCoreActivator.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/JBossLiveReloadCoreActivator.java
@@ -6,7 +6,7 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.core.runtime.Plugin;
 import org.eclipse.wst.server.core.IServer;
 import org.jboss.tools.livereload.core.internal.server.jetty.LiveReloadServer;
 import org.jboss.tools.livereload.core.internal.util.Logger;
@@ -19,7 +19,7 @@ import org.osgi.framework.BundleContext;
 /**
  * The activator class controls the plug-in life cycle
  */
-public class JBossLiveReloadCoreActivator extends AbstractUIPlugin {
+public class JBossLiveReloadCoreActivator extends Plugin {
 
 	/** The plug-in ID. */
 	public static final String PLUGIN_ID = "org.jboss.tools.livereload.core"; //$NON-NLS-1$

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/server/jetty/JettyServerRunner.java
@@ -44,6 +44,8 @@ public class JettyServerRunner implements Runnable {
 
 	/**
 	 * Starts the server
+	 * @param liveReloadServer the {@link Server} to start
+	 * @return the corresponding {@link JettyServerRunner} if the server started, <code>null</code> otherwise.
 	 * 
 	 * @throws TimeoutException
 	 */
@@ -70,9 +72,16 @@ public class JettyServerRunner implements Runnable {
 			throw new TimeoutException("Failed to start " + liveReloadServer + " within expected time (reason: timeout)");
 		}
 		Logger.debug("Server {} started (success={})", liveReloadServer, runner.status.isOK());
-		return runner;
+		if(runner.status.isOK()) {
+			return runner;
+		} 
+		return null;
 	}
 
+	/**
+	 * Stops the given {@link JettyServerRunner} associated with a Jetty {@link Server}
+	 * @param runner the runner to stop
+	 */
 	public static void stop(final JettyServerRunner runner) {
 		if (runner != null) {
 			try {

--- a/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/PathBuilder.java
+++ b/plugins/org.jboss.tools.livereload.core/src/org/jboss/tools/livereload/core/internal/util/PathBuilder.java
@@ -1,0 +1,62 @@
+package org.jboss.tools.livereload.core.internal.util;
+
+/**
+ * Convenient utility class to build URL path and make sure {@code /} separators
+ * are properly handled.
+ */
+public class PathBuilder {
+
+	private final StringBuilder path = new StringBuilder();
+
+	/**
+	 * Constructor helper
+	 * @param pathFragment the initial path fragment to begin with
+	 * @return a new instance of the {@link PathBuilder}
+	 */
+	public static PathBuilder from(final String pathFragment) {
+		final PathBuilder pathBuilder = new PathBuilder();
+		return pathBuilder.path(pathFragment);
+	}
+
+	/**
+	 * Adds the given {@code pathFragment} to the current path, while making
+	 * sure that a single {@code '/'} character is used to separate the given
+	 * {@code pathFragment} from the previous ones.
+	 * 
+	 * @param pathFragment
+	 * @return this {@link PathBuilder}
+	 */
+	public PathBuilder path(final String pathFragment) {
+		if (pathFragment == null) {
+			return this;
+		}
+		if (!pathFragment.startsWith("/")) {
+			if (!currentPathEndsWith('/')) {
+				this.path.append("/").append(pathFragment);
+			} else if (currentPathEndsWith('/')) {
+				this.path.append(pathFragment);
+			}
+		} else {
+			if (!currentPathEndsWith('/')) {
+				this.path.append(pathFragment);
+			} else if (currentPathEndsWith('/') && pathFragment.length() > 1) {
+				this.path.append(pathFragment.substring(1));
+			} else if (this.path.toString().length() == 0) {
+				this.path.append(pathFragment);
+			}
+		}
+		return this;
+	}
+	
+	private boolean currentPathEndsWith(final char lastChar) {
+		return this.path.length() > 0 && this.path.charAt(this.path.length() - 1) == lastChar;
+	}
+
+	/**
+	 * @return a {@link String} representation of the Path 
+	 */
+	public String build() {
+		return this.path.toString();
+	}
+
+}

--- a/plugins/org.jboss.tools.livereload.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.livereload.ui/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.databinding.property;bundle-version="1.4.200",
  org.eclipse.jface.databinding,
  org.eclipse.ui.workbench.texteditor;bundle-version="3.9.100",
- org.eclipse.ui.ide;bundle-version="3.11.0"
+ org.eclipse.ui.ide;bundle-version="3.11.0",
+ org.eclipse.jst.server.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/core-2.2.jar,

--- a/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadProxyVisibilityTester.java
+++ b/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadProxyVisibilityTester.java
@@ -31,7 +31,7 @@ public class OpenInWebBrowserViaLiveReloadProxyVisibilityTester extends Property
 			return false;
 		}
 		final IServer appServer = appModule.getServer();
-		return appServer != null && !WSTUtils.OPENSHIFT_SERVER_TYPE.equals(appServer.getServerType().getId());
+		return appServer != null && !WSTUtils.OPENSHIFT_EXPRESS_SERVER_TYPE.equals(appServer.getServerType().getId());
 	}
 
 }

--- a/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadUtils.java
+++ b/plugins/org.jboss.tools.livereload.ui/src/org/jboss/tools/livereload/ui/internal/command/OpenInWebBrowserViaLiveReloadUtils.java
@@ -185,7 +185,8 @@ public class OpenInWebBrowserViaLiveReloadUtils {
 					}
 				});
 			}
-		} catch (MalformedURLException | PartInitException e) {
+		} catch (MalformedURLException | CoreException e) {
+			MessageDialog.openError(Display.getDefault().getActiveShell(), "LiveReload Error", e.getMessage());
 			Logger.error("Failed to Open in Web Browser via LiveReload", e);
 		}
 	}
@@ -199,15 +200,15 @@ public class OpenInWebBrowserViaLiveReloadUtils {
 		return new URL("http", host, port, location.toString());
 	}
 
-	private static URL computeURL(final IServerModule appModule) throws MalformedURLException {
+	private static URL computeURL(final IServerModule appModule) throws MalformedURLException, CoreException {
 		final LiveReloadProxyServer liveReloadProxyServer = WSTUtils.findLiveReloadProxyServer(appModule.getServer());
 		if(liveReloadProxyServer == null) {
 			return null;
 		}
 		final int proxyPort = liveReloadProxyServer.getProxyPort();
 		final String host = liveReloadProxyServer.getProxyHost();
-		final URL url = new URL("http", host, proxyPort, "/" + appModule.getModule()[0].getName());
-		return url;
+		final URL moduleURL = WSTUtils.getModuleURL(host, proxyPort, appModule.getServer(), appModule.getModule()[0]);
+		return moduleURL;
 	}
 
 }

--- a/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
@@ -37,7 +37,8 @@ Require-Bundle: org.eclipse.ui,
  ch.qos.logback.classic;bundle-version="1.0.0",
  ch.qos.logback.core;bundle-version="1.0.0",
  org.jboss.tools.locus.mockito;bundle-version="1.9.5",
- org.assertj.core;bundle-version="2.1.0"
+ org.assertj.core;bundle-version="2.1.0",
+ org.eclipse.jst.server.core;bundle-version="1.2.400"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/PathBuilderTestCase.java
+++ b/tests/org.jboss.tools.livereload.test/src/org/jboss/tools/livereload/internal/util/PathBuilderTestCase.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package org.jboss.tools.livereload.internal.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.tools.livereload.core.internal.util.PathBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Testing the {@link PathBuilder} class.
+ */
+@RunWith(Parameterized.class)
+public class PathBuilderTestCase {
+
+	@Parameters(name = "[{index}] expect ''{0}'' == ''{1}''")
+	public static Object[][] data() {
+		return new Object[][] { new Object[] { PathBuilder.from("/").build(), "/" },
+				new Object[] { PathBuilder.from("/").path("/").build(), "/" },
+				new Object[] { PathBuilder.from("/").path(null).path("/").build(), "/" },
+				new Object[] { PathBuilder.from("/").path("/foo").build(), "/foo" },
+				new Object[] { PathBuilder.from("/").path("/foo").path("/").build(), "/foo/" },
+				new Object[] { PathBuilder.from("/").path("foo/").path("/").build(), "/foo/" }, 
+				new Object[] { PathBuilder.from("/").path("/foo/").path("/").build(), "/foo/" }, 
+				};
+	}
+
+	@Parameter(0)
+	public String path;
+
+	@Parameter(1)
+	public String expectation;
+
+	@Test
+	public void shouldBuildPath() {
+		assertThat(path).isEqualTo(expectation);
+	}
+
+}


### PR DESCRIPTION
For OpenShift3 servers, we need to retrieve the IExtendedPropertiesProvider
and then its extended properties and the welcomePageUrl because the server
hostname is 'localhost'.