### PR TITLE
JBIDE-22029 - For JBIDE 4.3.1.CR1: Prepare for Final/GA [LiveReload]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.3.1.CR1-SNAPSHOT</version>
+		<version>4.3.1.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>livereload</artifactId>


### PR DESCRIPTION
Updated parent pom to 4.3.1.Final-SNAPSHOT

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>