### PR TITLE
JBIDE-23202 - For JBIDE 4.4.2.AM1: Prepare for 4.4.2.AM1 / 10.2.0.AM1…

### DIFF
--- a/features/org.jboss.tools.livereload.feature/feature.xml
+++ b/features/org.jboss.tools.livereload.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
    id="org.jboss.tools.livereload.feature"
    label="%featureName"
-   version="1.4.1.qualifier"
+   version="1.4.2.qualifier"
    provider-name="%featureProvider"
    license-feature="org.jboss.tools.foundation.license.feature"
    license-feature-version="0.0.0">

--- a/features/org.jboss.tools.livereload.feature/pom.xml
+++ b/features/org.jboss.tools.livereload.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.livereload</groupId>
 		<artifactId>features</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload.features</groupId>
 	<artifactId>org.jboss.tools.livereload.feature</artifactId>

--- a/features/org.jboss.tools.livereload.test.feature/feature.xml
+++ b/features/org.jboss.tools.livereload.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
    id="org.jboss.tools.livereload.test.feature"
    label="%featureName"
-   version="1.4.1.qualifier"
+   version="1.4.2.qualifier"
    provider-name="%featureProvider"
    license-feature="org.jboss.tools.foundation.license.feature"
    license-feature-version="0.0.0">

--- a/features/org.jboss.tools.livereload.test.feature/pom.xml
+++ b/features/org.jboss.tools.livereload.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.livereload</groupId>
 		<artifactId>features</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload.features</groupId>
 	<artifactId>org.jboss.tools.livereload.test.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>livereload</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools LiveReload Core
 Bundle-SymbolicName: org.jboss.tools.livereload.core;singleton:=true
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.4.2.qualifier
 Bundle-Activator: org.jboss.tools.livereload.core.internal.JBossLiveReloadCoreActivator
 Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.livereload.core/pom.xml
+++ b/plugins/org.jboss.tools.livereload.core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.livereload</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload.plugins</groupId>
 	<artifactId>org.jboss.tools.livereload.core</artifactId>

--- a/plugins/org.jboss.tools.livereload.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.livereload.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools LiveReload UI
 Bundle-SymbolicName: org.jboss.tools.livereload.ui;singleton:=true
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.4.2.qualifier
 Bundle-Activator: org.jboss.tools.livereload.ui.JBossLiveReloadUIActivator
 Bundle-Vendor: JBoss by Red Hat
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.livereload.ui/pom.xml
+++ b/plugins/org.jboss.tools.livereload.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.livereload</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload.plugins</groupId>
 	<artifactId>org.jboss.tools.livereload.ui</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>livereload</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>livereload</artifactId>
 	<name>jbosstools-livereload</name>
-	<version>1.4.1-SNAPSHOT</version>
+	<version>1.4.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-livereload.git</tycho.scmUrl>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>livereload</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload</groupId>
 	<artifactId>livereload.site</artifactId>

--- a/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools LiveReload Test
 Bundle-SymbolicName: org.jboss.tools.livereload.test;singleton:=true
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.4.2.qualifier
 Bundle-Activator: org.jboss.tools.livereload.internal.LiveReloadTestActivator
 Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.eclipse.ui,

--- a/tests/org.jboss.tools.livereload.test/pom.xml
+++ b/tests/org.jboss.tools.livereload.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.livereload</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload.tests</groupId>
 	<artifactId>org.jboss.tools.livereload.test</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>livereload</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.livereload</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
… [LiveReload]

Bumping component version to 1.4.2

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>