### PR TITLE
JBIDE-23415 - use Import-Package instead of Require-Bundle for slf4j.api

### DIFF
--- a/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
@@ -33,7 +33,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.wst.common.modulecore;bundle-version="1.2.300",
  org.eclipse.jst.server.tomcat.core;bundle-version="1.1.403",
  org.eclipse.wst.web,
- org.slf4j.api;bundle-version="1.6.4",
  ch.qos.logback.classic;bundle-version="1.0.0",
  ch.qos.logback.core;bundle-version="1.0.0",
  org.jboss.tools.locus.mockito;bundle-version="1.9.5",
@@ -47,4 +46,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Import-Package: javax.servlet;version="3.1.0",
  javax.servlet.annotation;version="3.1.0",
- javax.servlet.http;version="3.1.0"
+ javax.servlet.http;version="3.1.0",
+ org.slf4j;version="1.7.2"


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>