### PR TITLE
JBIDE-24007 move up to Jetty [9.4.0,9.4.1)

### DIFF
--- a/features/org.jboss.tools.livereload.feature/feature.xml
+++ b/features/org.jboss.tools.livereload.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
    id="org.jboss.tools.livereload.feature"
    label="%featureName"
-   version="1.4.3.qualifier"
+   version="1.5.0.qualifier"
    provider-name="%featureProvider"
    license-feature="org.jboss.tools.foundation.license.feature"
    license-feature-version="0.0.0">

--- a/features/org.jboss.tools.livereload.feature/pom.xml
+++ b/features/org.jboss.tools.livereload.feature/pom.xml
@@ -10,5 +10,6 @@
 	</parent>
 	<groupId>org.jboss.tools.livereload.features</groupId>
 	<artifactId>org.jboss.tools.livereload.feature</artifactId>
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.jboss.tools.livereload.test.feature/feature.xml
+++ b/features/org.jboss.tools.livereload.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
    id="org.jboss.tools.livereload.test.feature"
    label="%featureName"
-   version="1.4.3.qualifier"
+   version="1.5.0.qualifier"
    provider-name="%featureProvider"
    license-feature="org.jboss.tools.foundation.license.feature"
    license-feature-version="0.0.0">

--- a/features/org.jboss.tools.livereload.test.feature/pom.xml
+++ b/features/org.jboss.tools.livereload.test.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.livereload.features</groupId>
 	<artifactId>org.jboss.tools.livereload.test.feature</artifactId>
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools LiveReload Core
 Bundle-SymbolicName: org.jboss.tools.livereload.core;singleton:=true
-Bundle-Version: 1.4.3.qualifier
+Bundle-Version: 1.5.0.qualifier
 Bundle-Activator: org.jboss.tools.livereload.core.internal.JBossLiveReloadCoreActivator
 Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.eclipse.core.runtime,
@@ -12,19 +12,19 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.common.modulecore;bundle-version="1.2.200",
  org.eclipse.jdt.core;bundle-version="3.8.2",
  org.eclipse.wst.server.core;bundle-version="1.4.0",
- org.eclipse.jetty.servlets;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.client;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.util;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.server;bundle-version="[9.3.9,9.4)";visibility:=reexport,
- org.eclipse.jetty.servlet;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.http;bundle-version="[9.3.9,9.4)";visibility:=reexport,
- org.eclipse.jetty.io;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.continuation;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.api;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.server;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.common;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.servlet;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.proxy;bundle-version="[9.3.9,9.4)",
+ org.eclipse.jetty.servlets;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.client;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.util;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.server;bundle-version="[9.4.0,9.4.1)";visibility:=reexport,
+ org.eclipse.jetty.servlet;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.http;bundle-version="[9.4.0,9.4.1)";visibility:=reexport,
+ org.eclipse.jetty.io;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.continuation;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.api;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.server;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.common;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.servlet;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.proxy;bundle-version="[9.4.0,9.4.1)",
  org.apache.commons.io;bundle-version="2.0.1",
  org.jboss.tools.common;bundle-version="3.4.0",
  org.eclipse.debug.core;bundle-version="3.8.0",

--- a/plugins/org.jboss.tools.livereload.core/pom.xml
+++ b/plugins/org.jboss.tools.livereload.core/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.jboss.tools.livereload.plugins</groupId>
 	<artifactId>org.jboss.tools.livereload.core</artifactId>
-
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -9,6 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.livereload</groupId>
 	<artifactId>livereload.site</artifactId>
+	<version>1.5.0-SNAPSHOT</version>
 	<name>livereload.site</name>
 	
 	<packaging>eclipse-repository</packaging>

--- a/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.livereload.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools LiveReload Test
 Bundle-SymbolicName: org.jboss.tools.livereload.test;singleton:=true
-Bundle-Version: 1.4.3.qualifier
+Bundle-Version: 1.5.0.qualifier
 Bundle-Activator: org.jboss.tools.livereload.internal.LiveReloadTestActivator
 Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.eclipse.ui,
@@ -13,17 +13,17 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.wst.server.core;bundle-version="1.5.0",
  org.eclipse.ui.ide;bundle-version="3.9.0",
  org.eclipse.debug.core;bundle-version="3.8.0",
- org.eclipse.jetty.client;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.security;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.util;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.server;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.servlet;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.api;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.server;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.servlet;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.common;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.websocket.client;bundle-version="[9.3.9,9.4)",
- org.eclipse.jetty.io;bundle-version="[9.3.9,9.4)",
+ org.eclipse.jetty.client;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.security;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.util;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.server;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.servlet;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.api;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.server;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.servlet;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.common;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.websocket.client;bundle-version="[9.4.0,9.4.1)",
+ org.eclipse.jetty.io;bundle-version="[9.4.0,9.4.1)",
  org.jboss.ide.eclipse.as.core;bundle-version="2.4.100",
  org.apache.commons.httpclient;bundle-version="3.1.0",
  org.apache.commons.io;bundle-version="2.0.1",

--- a/tests/org.jboss.tools.livereload.test/pom.xml
+++ b/tests/org.jboss.tools.livereload.test/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 	<groupId>org.jboss.tools.livereload.tests</groupId>
 	<artifactId>org.jboss.tools.livereload.test</artifactId>
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>


### PR DESCRIPTION
upversion affected plugins to 1.5.0

bump features to 1.5.0

bump update site to 1.5.0-SNAPSHOT


Signed-off-by: Jeff MAURY <jmaury@redhat.com>