### PR TITLE
JBIDE-26027 use...

### DIFF
--- a/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.livereload.core/META-INF/MANIFEST.MF
@@ -33,7 +33,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.5.0",
  com.fasterxml.jackson.core.jackson-core;bundle-version="2.5.0",
  com.fasterxml.jackson.core.jackson-databind;bundle-version="2.5.0",
- org.apache.aries.spifly.dynamic.bundle;bundle-version="1.0.2",
+ org.apache.aries.spifly.dynamic.bundle;bundle-version="1.0.10",
  org.jboss.tools.usage;bundle-version="2.1.1",
  org.eclipse.core.commands
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.tools.livereload.test/pom.xml
+++ b/tests/org.jboss.tools.livereload.test/pom.xml
@@ -58,22 +58,6 @@
 					</excludes>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tychoVersion}</version>
-				<configuration>
-					<filters>
-						<filter>
-							<type>p2-installable-unit</type>
-							<id>org.objectweb.asm</id>
-							<restrictTo>
-								<versionRange>[5.0,6.0)</versionRange>
-							</restrictTo>
-						</filter>
-					</filters>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
JBIDE-26027 use org.apache.aries.spifly.dynamic.bundle;bundle-version=1.0.10, which works with ASM 6

DO NOT MERGE until new TP 4.80.0.AM2-SNAPSHOT is available against which to build this.

Signed-off-by: nickboldt <nboldt@redhat.com>